### PR TITLE
Ensure text file attributes for source files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,36 @@
+* text=auto
+
+*.js text eol=lf
+*.jsx text eol=lf
+*.ts text eol=lf
+*.tsx text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.graphql text eol=lf
+*.css text eol=lf
+*.scss text eol=lf
+*.html text eol=lf
+*.xml text eol=lf
+*.sh text eol=lf
+*.gradle text eol=lf
+*.java text eol=lf
+*.kt text eol=lf
+*.properties text eol=lf
+
+# Ensure Expo and React Native config files treated as text
+app.json text eol=lf
+metro.config.js text eol=lf
+babel.config.js text eol=lf
+index.js text eol=lf
+App.tsx text eol=lf
+
+# Prevent Git from treating binary assets incorrectly
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.ttf binary
+*.otf binary


### PR DESCRIPTION
## Summary
- add a `.gitattributes` file so JavaScript, TypeScript, JSON, Markdown, and config sources are always stored as plain text with LF endings
- classify common binary asset extensions to avoid mis-detection as text

## Testing
- npm install *(fails: registry access returns 403 in sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf5dd9cee08321934380ad5883f423