### PR TITLE
Add CI with GitHub Actions (Node 20)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci || npm install
+
+      - name: Typecheck
+        run: |
+          if npm run | grep -q "typecheck"; then
+            npm run typecheck
+          else
+            npx tsc --noEmit || true
+          fi
+
+      - name: Lint
+        run: |
+          if npm run | grep -q "lint"; then
+            npm run lint
+          else
+            npx eslint . || true
+          fi
+
+      - name: Test
+        run: |
+          if npm run | grep -q "test"; then
+            npm test -- --ci || npm test -- --ci --passWithNoTests
+          else
+            echo "No tests configured. Skipping."
+          fi

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # DealMaster React Native App
 
+[![CI status](https://github.com/<OWNER>/<REPO>/actions/workflows/ci.yml/badge.svg)](https://github.com/<OWNER>/<REPO>/actions/workflows/ci.yml)
+
 A React Native starter project bootstrapped with TypeScript that showcases a simple authentication flow powered by Zustand and Axios. The application includes Login, Home, and Settings screens connected with React Navigation.
 
 ## Features

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "lint": "eslint .",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "jest --ci"
   },
   "dependencies": {
     "@babel/runtime": "^7.23.7",


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs install, typecheck, lint, and test jobs on Node.js 20 with fallbacks for missing scripts
- add a Jest test script so CI can execute the test step when available
- surface the new CI workflow in the README with a status badge

## Testing
- `npm install` *(fails: 403 Forbidden fetching @babel/core from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68cf644991b08321b2fbbceeee6870ed