### PR TITLE
Fix CI: replace legacy babel plugin with @babel/plugin-transform-inline-environment-variables

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,7 +2,7 @@ module.exports = {
   presets: ['module:metro-react-native-babel-preset'],
   plugins: [
     [
-      'transform-inline-environment-variables',
+      '@babel/plugin-transform-inline-environment-variables',
       {
         include: ['API_URL'],
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,8 @@
         "@types/react": "18.2.43",
         "@types/react-native": "0.72.5",
         "@types/react-test-renderer": "18.0.0",
+        "@babel/plugin-transform-inline-environment-variables": "^7",
         "babel-jest": "^29.7.0",
-        "babel-plugin-transform-inline-environment-variables": "^0.4.4",
         "eslint": "^8.55.0",
         "jest": "^29.7.0",
         "metro-react-native-babel-preset": "^0.76.7",
@@ -4879,12 +4879,6 @@
       "dependencies": {
         "@babel/plugin-syntax-flow": "^7.12.1"
       }
-    },
-    "node_modules/babel-plugin-transform-inline-environment-variables": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-environment-variables/-/babel-plugin-transform-inline-environment-variables-0.4.4.tgz",
-      "integrity": "sha512-bJILBtn5a11SmtR2j/3mBOjX4K3weC6cq+NNZ7hG22wCAqpc3qtj/iN7dSe9HDiS46lgp1nHsQgeYrea/RUe+g==",
-      "dev": true
     },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@babel/preset-env": "^7.23.7",
     "@react-native-community/eslint-config": "^3.2.0",
     "@react-native/metro-config": "^0.76.7",
-    "babel-plugin-transform-inline-environment-variables": "^0.5.1",
+    "@babel/plugin-transform-inline-environment-variables": "^7",
     "@types/react": "18.2.43",
     "@types/react-native": "0.72.5",
     "@types/react-test-renderer": "18.0.0",


### PR DESCRIPTION
## Summary
- replace the deprecated `babel-plugin-transform-inline-environment-variables` usage with `@babel/plugin-transform-inline-environment-variables`
- update the Babel configuration and lockfile metadata to drop the legacy entry

Old plugin version didn’t exist in the registry; switch to maintained @babel/ plugin and refresh lockfile so CI can install.

## Testing
- npm install *(fails in container: ENETUNREACH when contacting registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d0df1967fc8321bea565cf6ab78cc7