### PR TITLE
Add offline TypeScript type checking configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Copy `.env.example` to `.env` and update the `API_URL` value to point to your ba
 ## Testing & Linting
 
 - Run `npm run lint` to check for lint issues
-- Run `npm run typecheck` to verify TypeScript typings
+- Run `npm run typecheck` to verify TypeScript typings using installed `@types` packages
+- When developing without registry access, run `npm run typecheck:offline` to fall back to the local stubs declared under `./types`
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "lint": "eslint .",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "typecheck:offline": "tsc -p tsconfig.offline.json"
   },
   "dependencies": {
     "@babel/runtime": "^7.23.7",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
-    "types": ["react", "react-native"]
+    "types": ["react", "react-native"],
+    "typeRoots": ["./node_modules/@types"]
   },
   "exclude": ["node_modules", "babel.config.js", "metro.config.js", "jest.config.js"]
 }

--- a/tsconfig.offline.json
+++ b/tsconfig.offline.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "typeRoots": ["./types", "./node_modules/@types"]
+  }
+}


### PR DESCRIPTION
## Summary
- point the default TypeScript configuration to the standard node_modules type roots
- add an offline TypeScript configuration that falls back to local stubs
- surface an npm script and README guidance for opting into the offline type checking mode

## Testing
- not run (CI)

------
https://chatgpt.com/codex/tasks/task_e_68d614951df8832180882be15c6d692f