### PR TITLE
chore(types): fix TS build, env helper, streaming compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,10 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: |
-          if [ -f package-lock.json ]; then
-            npm ci
-          else
-            npm install --no-audit --prefer-offline --legacy-peer-deps
-          fi
+        run: npm ci
 
       - name: Typecheck
-        run: npx tsc --noEmit
+        run: npm run typecheck
 
       - name: Lint
-        run: npx eslint . --max-warnings=0
+        run: npm run lint -- --max-warnings=0

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@babel/preset-env": "^7.23.7",
         "@react-native-community/eslint-config": "^3.2.0",
         "@react-native/metro-config": "^0.76.7",
+        "@types/node": "^24.5.2",
         "@types/react": "18.2.43",
         "@types/react-native": "0.72.5",
         "@types/react-test-renderer": "18.0.0",
@@ -4059,6 +4060,7 @@
       "version": "24.5.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
       "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
+      "dev": true,
       "dependencies": {
         "undici-types": "~7.12.0"
       }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@react-native-community/eslint-config": "^3.2.0",
     "@react-native/metro-config": "^0.76.7",
     "@babel/plugin-transform-inline-environment-variables": "file:vendor/@babel/plugin-transform-inline-environment-variables",
+    "@types/node": "^24.5.2",
     "@types/react": "18.2.43",
     "@types/react-native": "0.72.5",
     "@types/react-test-renderer": "18.0.0",

--- a/src/ai/generateChat.ts
+++ b/src/ai/generateChat.ts
@@ -1,0 +1,131 @@
+import {getEnvVar} from '../utils/env';
+import {ChatMessage, ChatCompletionChunk} from './types';
+
+export interface GenerateChatOptions {
+  messages: ChatMessage[];
+  signal?: AbortSignal;
+  onToken?: (token: string) => void;
+}
+
+export interface GenerateChatResult {
+  message: ChatMessage;
+}
+
+const GPT_MODEL = 'gpt-5';
+const API_URL = 'https://api.openai.com/v1/chat/completions';
+
+const readApiKey = (): string | undefined =>
+  getEnvVar('GPT5_API_KEY') ?? getEnvVar('OPENAI_API_KEY');
+
+const getTextDecoder = async () => {
+  const GlobalTextDecoder = (globalThis as unknown as {TextDecoder?: typeof TextDecoder})
+    .TextDecoder;
+  if (GlobalTextDecoder) {
+    return new GlobalTextDecoder('utf-8');
+  }
+
+  const util = await import('util');
+  return new util.TextDecoder('utf-8');
+};
+
+const emitDelta = (
+  chunk: string,
+  onToken: ((token: string) => void) | undefined,
+  buffer: {text: string},
+) => {
+  const lines = chunk.split('\n');
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || !trimmed.startsWith('data:')) {
+      continue;
+    }
+    const data = trimmed.replace(/^data:\s*/, '');
+    if (!data || data === '[DONE]') {
+      continue;
+    }
+
+    try {
+      const parsed = JSON.parse(data) as ChatCompletionChunk;
+      const delta = parsed.choices?.[0]?.delta?.content;
+      if (typeof delta === 'string' && delta.length > 0) {
+        buffer.text += delta;
+        onToken?.(delta);
+      }
+    } catch (error) {
+      // Ignore malformed JSON chunks and continue streaming.
+    }
+  }
+};
+
+const parseCompleteResponse = async (response: Response): Promise<ChatMessage> => {
+  const text = await response.text();
+  try {
+    const json = JSON.parse(text) as ChatCompletionChunk;
+    const content =
+      json.choices?.[0]?.delta?.content ??
+      json.choices?.[0]?.message?.content ??
+      '';
+    return {role: 'assistant', content};
+  } catch (error) {
+    return {role: 'assistant', content: text};
+  }
+};
+
+export const generateChat = async ({
+  messages,
+  signal,
+  onToken,
+}: GenerateChatOptions): Promise<GenerateChatResult> => {
+  const apiKey = readApiKey();
+  if (!apiKey) {
+    throw new Error('Missing GPT API key');
+  }
+
+  const response = await fetch(API_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: GPT_MODEL,
+      messages,
+      stream: true,
+    }),
+    signal,
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => response.statusText);
+    throw new Error(errorText || `Request failed with status ${response.status}`);
+  }
+
+  const buffer = {text: ''};
+
+  const body = response.body;
+
+  if (body && typeof body.getReader === 'function') {
+    const reader = body.getReader();
+    const textDecoder = await getTextDecoder();
+
+    while (true) {
+      const {value, done} = await reader.read();
+      if (done) {
+        break;
+      }
+      if (!value) {
+        continue;
+      }
+      const chunk = textDecoder.decode(value, {stream: true});
+      emitDelta(chunk, onToken, buffer);
+    }
+
+    return {message: {role: 'assistant', content: buffer.text}};
+  }
+
+  const message = await parseCompleteResponse(response);
+  if (message.content.length > 0) {
+    onToken?.(message.content);
+  }
+  return {message};
+};

--- a/src/ai/types.ts
+++ b/src/ai/types.ts
@@ -1,0 +1,13 @@
+export type ChatRole = 'system' | 'user' | 'assistant';
+
+export interface ChatMessage {
+  role: ChatRole;
+  content: string;
+}
+
+export interface ChatCompletionChunk {
+  choices?: Array<{
+    delta?: Partial<ChatMessage>;
+    message?: ChatMessage;
+  }>;
+}

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -4,6 +4,7 @@ import {createNativeStackNavigator} from '@react-navigation/native-stack';
 import LoginScreen from '../screens/LoginScreen';
 import HomeScreen from '../screens/HomeScreen';
 import SettingsScreen from '../screens/SettingsScreen';
+import ChatScreen from '../screens/ChatScreen';
 import {useAuthStore} from '../store/useAuthStore';
 import {RootStackParamList} from './types';
 
@@ -18,6 +19,7 @@ const AppNavigator: React.FC = () => {
         {isAuthenticated ? (
           <>
             <Stack.Screen name="Home" component={HomeScreen} />
+            <Stack.Screen name="Chat" component={ChatScreen} />
             <Stack.Screen name="Settings" component={SettingsScreen} />
           </>
         ) : (

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -2,4 +2,5 @@ export type RootStackParamList = {
   Login: undefined;
   Home: undefined;
   Settings: undefined;
+  Chat: undefined;
 };

--- a/src/screens/ChatScreen.tsx
+++ b/src/screens/ChatScreen.tsx
@@ -1,0 +1,374 @@
+import React, {useCallback, useMemo, useRef, useState} from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  KeyboardAvoidingView,
+  ListRenderItem,
+  Platform,
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import {NativeStackScreenProps} from '@react-navigation/native-stack';
+import {colors} from '../theme/colors';
+import {generateChat} from '../ai/generateChat';
+import {ChatMessage} from '../ai/types';
+import {RootStackParamList} from '../navigation/types';
+import {useSettingsStore} from '../store/useSettingsStore';
+import {getEnvVar} from '../utils/env';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'Chat'>;
+
+const SYSTEM_PROMPT: ChatMessage = {
+  role: 'system',
+  content:
+    'You are DealMaster AI, an enthusiastic shopping assistant that helps users discover amazing deals.',
+};
+
+const ChatScreen: React.FC<Props> = () => {
+  const [input, setInput] = useState('');
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const abortController = useRef<AbortController | null>(null);
+  const messagesRef = useRef<ChatMessage[]>(messages);
+  const envOverrides = useSettingsStore(state => state.envOverrides);
+
+  const hasApiKey = useMemo(() => {
+    const override = envOverrides.GPT5_API_KEY ?? envOverrides.OPENAI_API_KEY;
+    if (override) {
+      return true;
+    }
+    return Boolean(getEnvVar('GPT5_API_KEY') ?? getEnvVar('OPENAI_API_KEY'));
+  }, [envOverrides]);
+
+  const updateMessages = useCallback((updater: (prev: ChatMessage[]) => ChatMessage[]) => {
+    setMessages(prev => {
+      const next = updater(prev);
+      messagesRef.current = next;
+      return next;
+    });
+  }, []);
+
+  const appendMessage = useCallback(
+    (message: ChatMessage) => {
+      updateMessages(prev => [...prev, message]);
+    },
+    [updateMessages],
+  );
+
+  const sendMessage = useCallback(async () => {
+    const trimmed = input.trim();
+    if (!trimmed || isStreaming) {
+      return;
+    }
+
+    if (!hasApiKey) {
+      setError('Add your GPT-5 API key in Settings to start chatting.');
+      return;
+    }
+
+    setError(null);
+    setInput('');
+    const userMessage: ChatMessage = {role: 'user', content: trimmed};
+    const conversation = [...messagesRef.current, userMessage];
+    appendMessage(userMessage);
+    setIsStreaming(true);
+
+    const controller = new AbortController();
+    abortController.current = controller;
+
+    let didStream = false;
+
+    try {
+      const result = await generateChat({
+        messages: [SYSTEM_PROMPT, ...conversation],
+        signal: controller.signal,
+        onToken: token => {
+          didStream = true;
+          updateMessages(prev => {
+            if (prev.length === 0) {
+              return [{role: 'assistant', content: token}];
+            }
+
+            const last = prev[prev.length - 1];
+            if (last.role === 'assistant') {
+              const next = [...prev];
+              next[next.length - 1] = {
+                ...last,
+                content: last.content + token,
+              };
+              return next;
+            }
+
+            return [...prev, {role: 'assistant', content: token}];
+          });
+        },
+      });
+
+      if (didStream) {
+        updateMessages(prev => {
+          if (prev.length === 0) {
+            return [result.message];
+          }
+          const next = [...prev];
+          const last = next[next.length - 1];
+          if (last.role === 'assistant') {
+            next[next.length - 1] = result.message;
+            return next;
+          }
+          return [...next, result.message];
+        });
+      } else {
+        appendMessage(result.message);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      setError(message);
+      updateMessages(prev => {
+        if (prev.length === 0) {
+          return prev;
+        }
+        const next = [...prev];
+        const last = next[next.length - 1];
+        if (last.role === 'assistant' && last.content.length === 0) {
+          next.pop();
+        }
+        return next;
+      });
+    } finally {
+      setIsStreaming(false);
+      abortController.current = null;
+    }
+  }, [appendMessage, hasApiKey, input, isStreaming, updateMessages]);
+
+  const handleStop = () => {
+    abortController.current?.abort();
+    abortController.current = null;
+    setIsStreaming(false);
+  };
+
+  const handleClear = () => {
+    abortController.current?.abort();
+    abortController.current = null;
+    setIsStreaming(false);
+    setError(null);
+    updateMessages(() => []);
+  };
+
+  const renderMessage: ListRenderItem<ChatMessage> = ({item}) => {
+    if (item.role === 'system') {
+      return null;
+    }
+
+    const isUser = item.role === 'user';
+    const bubbleStyle = [
+      styles.messageBubble,
+      isUser ? styles.userBubble : styles.assistantBubble,
+    ];
+    const textStyle = isUser ? styles.userText : styles.assistantText;
+
+    return (
+      <View style={styles.messageRow}>
+        <View style={bubbleStyle}>
+          <Text style={textStyle}>{item.content}</Text>
+        </View>
+      </View>
+    );
+  };
+
+  const trimmedInput = input.trim();
+  const disableSendButton = !isStreaming && trimmedInput.length === 0;
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        style={styles.flex}
+        keyboardVerticalOffset={16}>
+        <View style={styles.header}>
+          <Text style={styles.title}>DealMaster Chat</Text>
+          <TouchableOpacity onPress={handleClear} accessibilityRole="button">
+            <Text style={styles.clearText}>Clear</Text>
+          </TouchableOpacity>
+        </View>
+        {!hasApiKey && (
+          <View style={styles.banner}>
+            <Text style={styles.bannerText}>
+              Add your GPT-5 API key in settings to enable responses.
+            </Text>
+          </View>
+        )}
+        <FlatList
+          data={messages}
+          renderItem={renderMessage}
+          keyExtractor={(_, index) => String(index)}
+          contentContainerStyle={styles.messagesContent}
+          ListEmptyComponent={
+            <View style={styles.emptyState}>
+              <Text style={styles.emptyTitle}>Start chatting</Text>
+              <Text style={styles.emptySubtitle}>
+                Ask DealMaster for personalized shopping tips and curated deals.
+              </Text>
+            </View>
+          }
+        />
+        {error && <Text style={styles.errorText}>{error}</Text>}
+        <View style={styles.inputRow}>
+          <TextInput
+            value={input}
+            onChangeText={setInput}
+            placeholder="Ask about the best deals..."
+            style={styles.input}
+            multiline
+            editable={!isStreaming}
+            accessibilityLabel="Chat input"
+          />
+          <TouchableOpacity
+            onPress={isStreaming ? handleStop : sendMessage}
+            style={[styles.sendButton, disableSendButton && styles.sendButtonDisabled]}
+            disabled={disableSendButton}>
+            {isStreaming ? (
+              <ActivityIndicator color={colors.white} />
+            ) : (
+              <Text style={styles.sendText}>Send</Text>
+            )}
+          </TouchableOpacity>
+        </View>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  flex: {
+    flex: 1,
+  },
+  header: {
+    paddingHorizontal: 20,
+    paddingTop: 24,
+    paddingBottom: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  clearText: {
+    color: colors.primary,
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  banner: {
+    marginHorizontal: 20,
+    marginBottom: 12,
+    padding: 12,
+    borderRadius: 12,
+    backgroundColor: '#fee2e2',
+  },
+  bannerText: {
+    color: colors.error,
+    fontSize: 14,
+  },
+  messagesContent: {
+    paddingHorizontal: 20,
+    paddingBottom: 16,
+  },
+  messageRow: {
+    marginBottom: 12,
+  },
+  messageBubble: {
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 16,
+    maxWidth: '85%',
+  },
+  userBubble: {
+    alignSelf: 'flex-end',
+    backgroundColor: colors.primary,
+  },
+  assistantBubble: {
+    alignSelf: 'flex-start',
+    backgroundColor: colors.white,
+    borderWidth: 1,
+    borderColor: '#e2e8f0',
+  },
+  userText: {
+    color: colors.white,
+    fontSize: 15,
+  },
+  assistantText: {
+    color: colors.text,
+    fontSize: 15,
+  },
+  emptyState: {
+    alignItems: 'center',
+    marginTop: 80,
+    paddingHorizontal: 24,
+  },
+  emptyTitle: {
+    fontSize: 20,
+    fontWeight: '600',
+    color: colors.text,
+  },
+  emptySubtitle: {
+    marginTop: 8,
+    fontSize: 14,
+    color: colors.muted,
+    textAlign: 'center',
+  },
+  errorText: {
+    color: colors.error,
+    textAlign: 'center',
+    marginHorizontal: 20,
+    marginBottom: 8,
+  },
+  inputRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    paddingHorizontal: 20,
+    paddingBottom: 24,
+  },
+  input: {
+    flex: 1,
+    minHeight: 48,
+    maxHeight: 120,
+    borderWidth: 1,
+    borderColor: '#e2e8f0',
+    borderRadius: 16,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    fontSize: 15,
+    color: colors.text,
+    backgroundColor: colors.white,
+  },
+  sendButton: {
+    backgroundColor: colors.primary,
+    borderRadius: 16,
+    paddingVertical: 12,
+    paddingHorizontal: 18,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginLeft: 12,
+  },
+  sendButtonDisabled: {
+    opacity: 0.6,
+  },
+  sendText: {
+    color: colors.white,
+    fontWeight: '600',
+    fontSize: 15,
+  },
+});
+
+export default ChatScreen;

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -47,6 +47,11 @@ const HomeScreen: React.FC<Props> = ({navigation}) => {
         <Text style={styles.title}>{"Today's Deals"}</Text>
         <PrimaryButton title="Settings" onPress={() => navigation.navigate('Settings')} />
       </View>
+      <PrimaryButton
+        title="Ask DealMaster AI"
+        onPress={() => navigation.navigate('Chat')}
+        style={styles.chatButton}
+      />
       <FlatList
         data={deals}
         keyExtractor={item => item.id}
@@ -114,6 +119,10 @@ const styles = StyleSheet.create({
   },
   logoutButton: {
     margin: 20,
+  },
+  chatButton: {
+    marginHorizontal: 20,
+    marginBottom: 16,
   },
   loadingContainer: {
     flex: 1,

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,17 +1,51 @@
-import React, {useState} from 'react';
-import {SafeAreaView, ScrollView, StyleSheet, Switch, Text, View} from 'react-native';
+import React, {useEffect, useMemo, useState} from 'react';
+import {
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Switch,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {colors} from '../theme/colors';
 import {useAuthStore} from '../store/useAuthStore';
 import PrimaryButton from '../components/PrimaryButton';
-import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {RootStackParamList} from '../navigation/types';
+import {useSettingsStore} from '../store/useSettingsStore';
+import {getEnvVar} from '../utils/env';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Settings'>;
+
+const API_KEY_NAME = 'GPT5_API_KEY';
 
 const SettingsScreen: React.FC<Props> = ({navigation}) => {
   const logout = useAuthStore(state => state.logout);
   const [notificationsEnabled, setNotificationsEnabled] = useState(true);
   const [biometricsEnabled, setBiometricsEnabled] = useState(false);
+  const envOverrides = useSettingsStore(state => state.envOverrides);
+  const setEnvVar = useSettingsStore(state => state.setEnvVar);
+  const savedApiKey = envOverrides[API_KEY_NAME] ?? '';
+  const [apiKeyInput, setApiKeyInput] = useState(savedApiKey);
+
+  useEffect(() => {
+    setApiKeyInput(savedApiKey);
+  }, [savedApiKey]);
+
+  const resolvedApiKey = useMemo(() => {
+    const override = envOverrides[API_KEY_NAME] ?? envOverrides.OPENAI_API_KEY;
+    if (override) {
+      return override;
+    }
+    return getEnvVar(API_KEY_NAME) ?? getEnvVar('OPENAI_API_KEY');
+  }, [envOverrides]);
+
+  const handleApiKeyChange = (value: string) => {
+    setApiKeyInput(value);
+    const normalized = value.trim();
+    setEnvVar(API_KEY_NAME, normalized.length > 0 ? normalized : undefined);
+  };
 
   return (
     <SafeAreaView style={styles.container}>
@@ -44,6 +78,28 @@ const SettingsScreen: React.FC<Props> = ({navigation}) => {
             onValueChange={setBiometricsEnabled}
             trackColor={{true: colors.primary, false: '#cbd5f5'}}
           />
+        </View>
+
+        <View style={styles.secretCard}>
+          <Text style={styles.settingTitle}>GPT-5 API Key</Text>
+          <Text style={styles.settingDescription}>
+            Store your API key locally to unlock the DealMaster chat assistant.
+          </Text>
+          <TextInput
+            value={apiKeyInput}
+            onChangeText={handleApiKeyChange}
+            placeholder="sk-..."
+            secureTextEntry
+            autoCapitalize="none"
+            autoCorrect={false}
+            style={styles.secretInput}
+            accessibilityLabel="GPT-5 API key input"
+          />
+          <Text style={styles.helperText}>
+            {resolvedApiKey
+              ? 'Your API key is ready to be used for chat requests.'
+              : 'Add an API key above to enable AI-powered replies.'}
+          </Text>
         </View>
 
         <PrimaryButton
@@ -99,6 +155,33 @@ const styles = StyleSheet.create({
     color: colors.muted,
     marginTop: 4,
     width: 220,
+  },
+  secretCard: {
+    backgroundColor: colors.white,
+    borderRadius: 16,
+    padding: 20,
+    marginBottom: 16,
+    shadowColor: colors.text,
+    shadowOffset: {width: 0, height: 6},
+    shadowOpacity: 0.05,
+    shadowRadius: 10,
+    elevation: 2,
+  },
+  secretInput: {
+    marginTop: 12,
+    borderWidth: 1,
+    borderColor: '#e2e8f0',
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    fontSize: 15,
+    color: colors.text,
+    backgroundColor: '#f8fafc',
+  },
+  helperText: {
+    marginTop: 8,
+    fontSize: 13,
+    color: colors.muted,
   },
   actionButton: {
     marginTop: 12,

--- a/src/store/useSettingsStore.ts
+++ b/src/store/useSettingsStore.ts
@@ -1,0 +1,40 @@
+import {create} from 'zustand';
+
+export type EnvOverrides = Record<string, string>;
+
+export interface SettingsState {
+  envOverrides: EnvOverrides;
+  setEnvVar: (name: string, value: string | undefined) => void;
+  clearEnvVar: (name: string) => void;
+}
+
+const normalizeName = (name: string): string => name.trim().toUpperCase();
+
+export const useSettingsStore = create<SettingsState>((set, get) => ({
+  envOverrides: {},
+  setEnvVar: (name, value) => {
+    const normalized = normalizeName(name);
+    set(state => {
+      const next = {...state.envOverrides};
+      if (value && value.length > 0) {
+        next[normalized] = value;
+      } else {
+        delete next[normalized];
+      }
+      return {envOverrides: next};
+    });
+  },
+  clearEnvVar: name => {
+    const normalized = normalizeName(name);
+    const existing = get().envOverrides;
+    if (normalized in existing) {
+      set(state => {
+        const next = {...state.envOverrides};
+        delete next[normalized];
+        return {envOverrides: next};
+      });
+    }
+  },
+}));
+
+export const selectEnvOverrides = (state: SettingsState) => state.envOverrides;

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,0 +1,118 @@
+import type {EnvOverrides} from '../store/useSettingsStore';
+import {selectEnvOverrides, useSettingsStore} from '../store/useSettingsStore';
+
+type MaybeRecord = Record<string, unknown> | null | undefined;
+
+const normalizeName = (name: string): string => name.trim().toUpperCase();
+
+const readFromRecord = (record: MaybeRecord, name: string): string | undefined => {
+  if (!record || typeof record !== 'object') {
+    return undefined;
+  }
+
+  const container = record as Record<string, unknown>;
+
+  const direct = container[name];
+  if (typeof direct === 'string') {
+    return direct;
+  }
+
+  const nestedKeys: Array<keyof typeof container> = [
+    'extra',
+    'manifest',
+    'manifest2',
+    'expoConfig',
+    'config',
+  ];
+
+  for (const key of nestedKeys) {
+    const value = container[key as string];
+    if (!value || typeof value !== 'object') {
+      continue;
+    }
+    if (key === 'manifest' || key === 'manifest2') {
+      const manifest = value as Record<string, unknown>;
+      const extra = manifest.extra;
+      if (extra && typeof extra === 'object') {
+        const match = (extra as Record<string, unknown>)[name];
+        if (typeof match === 'string') {
+          return match;
+        }
+      }
+      continue;
+    }
+    const nested = value as Record<string, unknown>;
+    const match = nested[name];
+    if (typeof match === 'string') {
+      return match;
+    }
+    if ('extra' in nested && typeof nested.extra === 'object' && nested.extra) {
+      const extra = nested.extra as Record<string, unknown>;
+      const extraMatch = extra[name];
+      if (typeof extraMatch === 'string') {
+        return extraMatch;
+      }
+    }
+  }
+
+  return undefined;
+};
+
+const readFromExpoGlobals = (name: string): string | undefined => {
+  const globalAny = globalThis as Record<string, unknown>;
+  const candidates: unknown[] = [
+    globalAny?.Expo && (globalAny.Expo as Record<string, unknown>).Constants,
+    globalAny?.Constants,
+    globalAny?.ExpoConstants,
+    globalAny?.expoConfig,
+    globalAny?.__expoConfig,
+    globalAny?.Config,
+    globalAny?.config,
+  ];
+
+  for (const candidate of candidates) {
+    const value = readFromRecord(candidate as MaybeRecord, name);
+    if (typeof value === 'string') {
+      return value;
+    }
+  }
+
+  return undefined;
+};
+
+const readFromSettings = (overrides: EnvOverrides, name: string): string | undefined =>
+  overrides[name];
+
+export const getEnvVar = (rawName: string): string | undefined => {
+  const name = normalizeName(rawName);
+  if (!name) {
+    return undefined;
+  }
+
+  const overrides = selectEnvOverrides(useSettingsStore.getState());
+  const fromSettings = readFromSettings(overrides, name);
+  if (fromSettings) {
+    return fromSettings;
+  }
+
+  const fromExpo = readFromExpoGlobals(name);
+  if (fromExpo) {
+    return fromExpo;
+  }
+
+  if (typeof process !== 'undefined' && typeof process?.env === 'object') {
+    const value = process.env?.[name];
+    if (typeof value === 'string' && value.length > 0) {
+      return value;
+    }
+  }
+
+  return undefined;
+};
+
+export const useEnvVar = (name: string): string | undefined => {
+  const overrides = useSettingsStore(state => state.envOverrides);
+  const normalized = normalizeName(name);
+
+  return getEnvVar(normalized) ?? overrides[normalized];
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",
-    "lib": ["esnext"],
+    "lib": ["es2021", "dom"],
     "allowJs": false,
     "jsx": "react-native",
     "noEmit": true,
@@ -11,7 +11,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
-    "types": ["react", "react-native"]
+    "types": ["react", "react-native", "node"]
   },
   "exclude": ["node_modules", "babel.config.js", "metro.config.js", "jest.config.js"]
 }


### PR DESCRIPTION
## Summary
- add a Zustand settings store plus an env helper that surfaces stored API keys and Expo/process fallbacks
- unify chat message typing, add the chat screen, and update the streaming generator to safely decode web and Node responses
- expand TypeScript libs, pull in @types/node, and update CI to run npm typecheck/lint scripts

## Testing
- npm run typecheck
- npm run lint -- --max-warnings=0

------
https://chatgpt.com/codex/tasks/task_e_68d8a662dab48321bf6cd4af8bac7ace