### PR TITLE
feat(memory): session persistence + auto summarization

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,11 +1,16 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import {StatusBar, useColorScheme} from 'react-native';
 import {SafeAreaProvider} from 'react-native-safe-area-context';
 import AppNavigator from './src/navigation/AppNavigator';
 import {colors} from './src/theme/colors';
+import {getDatabase} from './src/storage/database';
 
 const App: React.FC = () => {
   const isDark = useColorScheme() === 'dark';
+
+  useEffect(() => {
+    getDatabase();
+  }, []);
 
   return (
     <SafeAreaProvider>

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@react-navigation/native": "^6.1.9",
     "@react-navigation/native-stack": "^6.9.17",
     "axios": "^1.6.7",
+    "react-native-sqlite-storage": "^6.1.12",
     "react": "18.2.0",
     "react-native": "0.72.10",
     "react-native-safe-area-context": "^4.7.4",

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -4,6 +4,8 @@ import {createNativeStackNavigator} from '@react-navigation/native-stack';
 import LoginScreen from '../screens/LoginScreen';
 import HomeScreen from '../screens/HomeScreen';
 import SettingsScreen from '../screens/SettingsScreen';
+import ChatListScreen from '../screens/ChatListScreen';
+import ChatScreen from '../screens/ChatScreen';
 import {useAuthStore} from '../store/useAuthStore';
 import {RootStackParamList} from './types';
 
@@ -18,6 +20,8 @@ const AppNavigator: React.FC = () => {
         {isAuthenticated ? (
           <>
             <Stack.Screen name="Home" component={HomeScreen} />
+            <Stack.Screen name="ChatList" component={ChatListScreen} options={{title: '對話列表'}} />
+            <Stack.Screen name="Chat" component={ChatScreen} options={({route}) => ({title: route.params.title})} />
             <Stack.Screen name="Settings" component={SettingsScreen} />
           </>
         ) : (

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -2,4 +2,6 @@ export type RootStackParamList = {
   Login: undefined;
   Home: undefined;
   Settings: undefined;
+  ChatList: undefined;
+  Chat: {chatId: number; title: string};
 };

--- a/src/screens/ChatListScreen.tsx
+++ b/src/screens/ChatListScreen.tsx
@@ -1,0 +1,168 @@
+import React, {useCallback, useState} from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  RefreshControl,
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import {useFocusEffect, useNavigation} from '@react-navigation/native';
+import {NativeStackNavigationProp} from '@react-navigation/native-stack';
+import PrimaryButton from '../components/PrimaryButton';
+import {colors} from '../theme/colors';
+import {RootStackParamList} from '../navigation/types';
+import {createChat, getChats, getLatestMessageForChat} from '../storage/chatRepository';
+import {ChatRecord} from '../storage/types';
+
+type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'ChatList'>;
+
+type ListItem = ChatRecord & {
+  latestMessage?: string;
+};
+
+const formatTimestamp = (timestamp: string) => {
+  const date = new Date(timestamp);
+  return date.toLocaleString();
+};
+
+const ChatListScreen: React.FC = () => {
+  const navigation = useNavigation<NavigationProp>();
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [chats, setChats] = useState<ListItem[]>([]);
+
+  const loadChats = useCallback(async () => {
+    try {
+      setLoading(true);
+      const chatRecords = await getChats();
+      const items: ListItem[] = [];
+      for (const chat of chatRecords) {
+        const latest = await getLatestMessageForChat(chat.id);
+        items.push({
+          ...chat,
+          latestMessage: latest?.content,
+        });
+      }
+      setChats(items);
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      loadChats();
+    }, [loadChats]),
+  );
+
+  const handleRefresh = useCallback(() => {
+    setRefreshing(true);
+    loadChats();
+  }, [loadChats]);
+
+  const handleCreateChat = useCallback(async () => {
+    const newChat = await createChat(`新的對話 ${new Date().toLocaleTimeString()}`);
+    await loadChats();
+    navigation.navigate('Chat', {chatId: newChat.id, title: newChat.title});
+  }, [loadChats, navigation]);
+
+  const renderItem = ({item}: {item: ListItem}) => (
+    <TouchableOpacity
+      style={styles.chatCard}
+      onPress={() => navigation.navigate('Chat', {chatId: item.id, title: item.title})}>
+      <Text style={styles.chatTitle}>{item.title}</Text>
+      <Text style={styles.chatSubtitle} numberOfLines={2}>
+        {item.latestMessage ?? '尚未開始對話'}
+      </Text>
+      <Text style={styles.chatTimestamp}>{formatTimestamp(item.updated_at)}</Text>
+    </TouchableOpacity>
+  );
+
+  if (loading && chats.length === 0) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator color={colors.primary} size="large" />
+        <Text style={styles.loadingText}>載入對話中…</Text>
+      </View>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.actionBar}>
+        <PrimaryButton title="建立新對話" onPress={handleCreateChat} />
+      </View>
+      <FlatList
+        data={chats}
+        keyExtractor={item => item.id.toString()}
+        renderItem={renderItem}
+        contentContainerStyle={styles.listContent}
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />}
+        ListEmptyComponent={<Text style={styles.emptyText}>目前尚無對話，先建立一個吧！</Text>}
+      />
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  actionBar: {
+    padding: 16,
+  },
+  listContent: {
+    paddingHorizontal: 16,
+    paddingBottom: 16,
+  },
+  chatCard: {
+    backgroundColor: colors.white,
+    borderRadius: 16,
+    padding: 16,
+    marginBottom: 12,
+    shadowColor: '#000',
+    shadowOffset: {width: 0, height: 2},
+    shadowOpacity: 0.1,
+    shadowRadius: 6,
+    elevation: 2,
+  },
+  chatTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: colors.text,
+  },
+  chatSubtitle: {
+    fontSize: 14,
+    color: colors.muted,
+    marginTop: 6,
+    minHeight: 40,
+  },
+  chatTimestamp: {
+    fontSize: 12,
+    color: colors.muted,
+    marginTop: 8,
+  },
+  emptyText: {
+    textAlign: 'center',
+    color: colors.muted,
+    marginTop: 40,
+  },
+  loadingContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.background,
+  },
+  loadingText: {
+    marginTop: 12,
+    color: colors.muted,
+  },
+});
+
+export default ChatListScreen;
+

--- a/src/screens/ChatScreen.tsx
+++ b/src/screens/ChatScreen.tsx
@@ -1,0 +1,289 @@
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  KeyboardAvoidingView,
+  Platform,
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import {NativeStackScreenProps} from '@react-navigation/native-stack';
+import {RootStackParamList} from '../navigation/types';
+import {
+  buildContextForPreview,
+  generateChat,
+  summarizeChatToDate,
+} from '../services/chatService';
+import {getMessagesForChat} from '../storage/chatRepository';
+import {MessageRecord} from '../storage/types';
+import PrimaryButton from '../components/PrimaryButton';
+import {colors} from '../theme/colors';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'Chat'>;
+
+const ChatScreen: React.FC<Props> = ({route}) => {
+  const {chatId} = route.params;
+  const [messages, setMessages] = useState<MessageRecord[]>([]);
+  const [contextPreview, setContextPreview] = useState<MessageRecord[]>([]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [sending, setSending] = useState(false);
+  const [summarizing, setSummarizing] = useState(false);
+
+  const pinnedSummary = useMemo(() => {
+    return [...messages].reverse().find(message => message.role === 'summary');
+  }, [messages]);
+
+  const loadMessages = useCallback(async () => {
+    setLoading(true);
+    try {
+      const history = await getMessagesForChat(chatId);
+      setMessages(history);
+      const preview = await buildContextForPreview(chatId);
+      setContextPreview(preview);
+    } finally {
+      setLoading(false);
+    }
+  }, [chatId]);
+
+  useEffect(() => {
+    loadMessages();
+  }, [loadMessages]);
+
+  const handleSend = useCallback(async () => {
+    if (!input.trim()) {
+      return;
+    }
+    try {
+      setSending(true);
+      await generateChat(chatId, input);
+      setInput('');
+      await loadMessages();
+    } finally {
+      setSending(false);
+    }
+  }, [chatId, input, loadMessages]);
+
+  const handleSummarize = useCallback(async () => {
+    try {
+      setSummarizing(true);
+      await summarizeChatToDate(chatId);
+      await loadMessages();
+    } finally {
+      setSummarizing(false);
+    }
+  }, [chatId, loadMessages]);
+
+  const renderMessage = ({item}: {item: MessageRecord}) => {
+    const isUser = item.role === 'user';
+    const isSummary = item.role === 'summary';
+    const containerStyle = [
+      styles.messageBubble,
+      isUser ? styles.userBubble : styles.assistantBubble,
+      isSummary && styles.summaryBubble,
+    ];
+    const textStyle = [styles.messageText, isUser ? styles.userText : styles.assistantText];
+
+    return (
+      <View style={containerStyle}>
+        <Text style={styles.metaLabel}>
+          {isSummary ? '摘要' : isUser ? '你' : 'DealMaster AI'}
+        </Text>
+        <Text style={[...textStyle, isSummary && styles.summaryText]}>{item.content}</Text>
+      </View>
+    );
+  };
+
+  if (loading && messages.length === 0) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator color={colors.primary} size="large" />
+        <Text style={styles.loadingText}>載入歷史訊息中…</Text>
+      </View>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <KeyboardAvoidingView
+        style={styles.container}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        keyboardVerticalOffset={Platform.OS === 'ios' ? 80 : 0}>
+        {pinnedSummary ? (
+          <View style={styles.pinnedSummary}>
+            <Text style={styles.summaryTitle}>一鍵總結</Text>
+            <Text style={styles.summaryContent}>{pinnedSummary.content}</Text>
+          </View>
+        ) : null}
+        <FlatList
+          data={messages}
+          keyExtractor={item => item.id.toString()}
+          renderItem={renderMessage}
+          contentContainerStyle={styles.listContent}
+          ListHeaderComponent={
+            contextPreview.length > 0 ? (
+              <View style={styles.contextPreview}>
+                <Text style={styles.contextTitle}>模型輸入預覽</Text>
+                {contextPreview.map(message => (
+                  <Text key={`${message.id}-${message.created_at}`} style={styles.contextText}>
+                    {`${message.role === 'user' ? '你' : '系統'}：${message.content}`}
+                  </Text>
+                ))}
+              </View>
+            ) : undefined
+          }
+        />
+        <View style={styles.actions}>
+          <PrimaryButton
+            title={summarizing ? '摘要中…' : '一鍵總結到目前'}
+            onPress={handleSummarize}
+            disabled={summarizing}
+          />
+        </View>
+        <View style={styles.inputRow}>
+          <TextInput
+            style={styles.input}
+            placeholder="輸入訊息…"
+            value={input}
+            onChangeText={setInput}
+            multiline
+          />
+          <PrimaryButton
+            title={sending ? '傳送中…' : '送出'}
+            onPress={handleSend}
+            disabled={sending}
+            style={styles.sendButton}
+          />
+        </View>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  container: {
+    flex: 1,
+  },
+  pinnedSummary: {
+    backgroundColor: '#F0F7FF',
+    borderRadius: 12,
+    padding: 16,
+    margin: 16,
+    borderWidth: 1,
+    borderColor: '#C8DCFF',
+  },
+  summaryTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 8,
+    color: colors.text,
+  },
+  summaryContent: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: colors.muted,
+  },
+  listContent: {
+    padding: 16,
+    paddingBottom: 80,
+  },
+  messageBubble: {
+    marginBottom: 12,
+    padding: 12,
+    borderRadius: 12,
+  },
+  userBubble: {
+    backgroundColor: '#D6F5D6',
+    alignSelf: 'flex-end',
+    maxWidth: '85%',
+  },
+  assistantBubble: {
+    backgroundColor: colors.white,
+    alignSelf: 'flex-start',
+    maxWidth: '85%',
+  },
+  summaryBubble: {
+    backgroundColor: '#FFF5D6',
+    borderColor: '#FFDD99',
+    borderWidth: 1,
+  },
+  messageText: {
+    fontSize: 15,
+    lineHeight: 21,
+  },
+  userText: {
+    color: colors.text,
+  },
+  assistantText: {
+    color: colors.text,
+  },
+  summaryText: {
+    color: '#8A5A00',
+  },
+  metaLabel: {
+    fontSize: 12,
+    marginBottom: 4,
+    color: colors.muted,
+  },
+  inputRow: {
+    flexDirection: 'row',
+    padding: 16,
+    alignItems: 'flex-end',
+    backgroundColor: colors.background,
+  },
+  input: {
+    flex: 1,
+    minHeight: 44,
+    maxHeight: 120,
+    padding: 12,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#E2E8F0',
+    backgroundColor: colors.white,
+  },
+  sendButton: {
+    marginLeft: 12,
+  },
+  actions: {
+    paddingHorizontal: 16,
+    paddingBottom: 8,
+  },
+  contextPreview: {
+    padding: 16,
+    backgroundColor: '#EEF2FF',
+    borderRadius: 12,
+    marginBottom: 16,
+  },
+  contextTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 8,
+    color: colors.text,
+  },
+  contextText: {
+    fontSize: 13,
+    lineHeight: 18,
+    color: colors.muted,
+    marginBottom: 4,
+  },
+  loadingContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.background,
+  },
+  loadingText: {
+    marginTop: 12,
+    color: colors.muted,
+  },
+});
+
+export default ChatScreen;
+

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -47,6 +47,12 @@ const HomeScreen: React.FC<Props> = ({navigation}) => {
         <Text style={styles.title}>{"Today's Deals"}</Text>
         <PrimaryButton title="Settings" onPress={() => navigation.navigate('Settings')} />
       </View>
+      <View style={styles.actions}>
+        <PrimaryButton
+          title="開啟 AI 對話"
+          onPress={() => navigation.navigate('ChatList')}
+        />
+      </View>
       <FlatList
         data={deals}
         keyExtractor={item => item.id}
@@ -114,6 +120,9 @@ const styles = StyleSheet.create({
   },
   logoutButton: {
     margin: 20,
+  },
+  actions: {
+    paddingHorizontal: 20,
   },
   loadingContainer: {
     flex: 1,

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -1,0 +1,81 @@
+import {addMessage, getMessagesForChat, updateChatTimestamp} from '../storage/chatRepository';
+import {MessageRecord} from '../storage/types';
+import {estimateTokenSize, summarizeMessages} from './summarizer';
+
+const TOKEN_LIMIT = 1800;
+const RECENT_MESSAGE_COUNT = 8;
+
+export type GenerateChatOptions = {
+  responder?: (messages: MessageRecord[]) => Promise<string>;
+};
+
+const defaultResponder = async (messages: MessageRecord[]) => {
+  const lastUser = [...messages].reverse().find(message => message.role === 'user');
+  if (!lastUser) {
+    return '你好！今天想聊些什麼？';
+  }
+  const context = messages
+    .filter(message => message.role !== 'summary')
+    .slice(-3)
+    .map(message => (message.role === 'user' ? `你說：「${message.content}」` : `我回覆：「${message.content}」`))
+    .join(' ');
+  return `收到你的訊息：「${lastUser.content}」。我會記得先前的脈絡：${context}`;
+};
+
+const injectSummaryIfNeeded = async (
+  chatId: number,
+  messages: MessageRecord[],
+): Promise<{context: MessageRecord[]; summary?: MessageRecord}> => {
+  const tokenSize = estimateTokenSize(messages);
+  if (tokenSize <= TOKEN_LIMIT) {
+    return {context: messages};
+  }
+
+  const historical = messages.slice(0, Math.max(0, messages.length - RECENT_MESSAGE_COUNT));
+  const recent = messages.slice(-RECENT_MESSAGE_COUNT);
+  const summaryContent = summarizeMessages(historical, {targetLength: 280});
+  const summaryMessage: MessageRecord = {
+    id: -1,
+    chat_id: chatId,
+    role: 'system',
+    content: `以下為較早對話的摘要：\n${summaryContent}`,
+    created_at: new Date().toISOString(),
+  };
+  return {
+    context: [summaryMessage, ...recent],
+    summary: summaryMessage,
+  };
+};
+
+export const generateChat = async (
+  chatId: number,
+  userMessage: string,
+  options?: GenerateChatOptions,
+) => {
+  const trimmed = userMessage.trim();
+  if (!trimmed) {
+    return;
+  }
+
+  await addMessage(chatId, 'user', trimmed);
+  const messages = await getMessagesForChat(chatId);
+  const {context} = await injectSummaryIfNeeded(chatId, messages);
+  const responder = options?.responder ?? defaultResponder;
+  const assistantReply = await responder(context);
+  await addMessage(chatId, 'assistant', assistantReply);
+};
+
+export const buildContextForPreview = async (chatId: number) => {
+  const messages = await getMessagesForChat(chatId);
+  const {context} = await injectSummaryIfNeeded(chatId, messages);
+  return context;
+};
+
+export const summarizeChatToDate = async (chatId: number) => {
+  const messages = await getMessagesForChat(chatId);
+  const summary = summarizeMessages(messages, {targetLength: 280});
+  const storedSummary = await addMessage(chatId, 'summary', summary);
+  await updateChatTimestamp(chatId);
+  return storedSummary;
+};
+

--- a/src/services/summarizer.ts
+++ b/src/services/summarizer.ts
@@ -1,0 +1,59 @@
+import {MessageRecord} from '../storage/types';
+
+const clamp = (value: number, min: number, max: number) => {
+  return Math.min(Math.max(value, min), max);
+};
+
+const toSentences = (text: string): string[] => {
+  return text
+    .replace(/\s+/g, ' ')
+    .split(/[.!?\n]+/)
+    .map(sentence => sentence.trim())
+    .filter(Boolean);
+};
+
+const buildBulletSummary = (messages: MessageRecord[], maxSentences: number) => {
+  const bullets: string[] = [];
+  for (const message of messages) {
+    const content = message.content.trim();
+    if (!content) {
+      continue;
+    }
+    const sentences = toSentences(content);
+    if (sentences.length === 0) {
+      continue;
+    }
+    const snippet = sentences.slice(0, 1).join(' ').slice(0, 140).trim();
+    bullets.push(`• ${snippet}`);
+    if (bullets.length >= maxSentences) {
+      break;
+    }
+  }
+  return bullets.join('\n');
+};
+
+export const summarizeMessages = (
+  messages: MessageRecord[],
+  options?: {targetLength?: number},
+): string => {
+  if (messages.length === 0) {
+    return '目前尚未有可供摘要的歷史訊息。';
+  }
+
+  const targetLength = options?.targetLength ?? 260;
+  const maxSentences = clamp(Math.ceil(targetLength / 70), 3, 6);
+  const bulletSummary = buildBulletSummary(messages, maxSentences);
+  const joined = bulletSummary || messages.map(m => m.content).join(' ');
+  const trimmed = joined.slice(0, clamp(targetLength, 200, 320));
+  return trimmed.endsWith('…') || trimmed.length < targetLength
+    ? trimmed
+    : `${trimmed}…`;
+};
+
+export const estimateTokenSize = (messages: MessageRecord[]): number => {
+  return messages.reduce((total, message) => {
+    const approxTokens = Math.ceil(message.content.split(/\s+/).filter(Boolean).length * 1.3);
+    return total + approxTokens;
+  }, 0);
+};
+

--- a/src/storage/chatRepository.ts
+++ b/src/storage/chatRepository.ts
@@ -1,0 +1,126 @@
+import {getDatabase} from './database';
+import {ChatRecord, MessageRecord} from './types';
+
+const mapChat = (row: any): ChatRecord => ({
+  id: row.id,
+  title: row.title,
+  created_at: row.created_at,
+  updated_at: row.updated_at,
+});
+
+const mapMessage = (row: any): MessageRecord => ({
+  id: row.id,
+  chat_id: row.chat_id,
+  role: row.role,
+  content: row.content,
+  created_at: row.created_at,
+});
+
+export const createChat = async (title: string): Promise<ChatRecord> => {
+  const db = await getDatabase();
+  const now = new Date().toISOString();
+  const result = await db.executeSql(
+    'INSERT INTO chats (title, created_at, updated_at) VALUES (?, ?, ?);',
+    [title, now, now],
+  );
+
+  const insertedId = result[0].insertId ?? 0;
+  const rows = await db.executeSql('SELECT * FROM chats WHERE id = ?;', [insertedId]);
+  const item = rows[0].rows.item(0);
+  return mapChat(item);
+};
+
+export const updateChatTimestamp = async (chatId: number) => {
+  const db = await getDatabase();
+  const now = new Date().toISOString();
+  await db.executeSql('UPDATE chats SET updated_at = ? WHERE id = ?;', [now, chatId]);
+};
+
+export const getChats = async (): Promise<ChatRecord[]> => {
+  const db = await getDatabase();
+  const result = await db.executeSql('SELECT * FROM chats ORDER BY updated_at DESC;');
+  const rows = result[0].rows;
+  const items: ChatRecord[] = [];
+  for (let i = 0; i < rows.length; i += 1) {
+    items.push(mapChat(rows.item(i)));
+  }
+  return items;
+};
+
+export const getChatById = async (chatId: number): Promise<ChatRecord | undefined> => {
+  const db = await getDatabase();
+  const result = await db.executeSql('SELECT * FROM chats WHERE id = ?;', [chatId]);
+  if (result[0].rows.length === 0) {
+    return undefined;
+  }
+  return mapChat(result[0].rows.item(0));
+};
+
+export const deleteChat = async (chatId: number) => {
+  const db = await getDatabase();
+  await db.executeSql('DELETE FROM chats WHERE id = ?;', [chatId]);
+};
+
+export const addMessage = async (
+  chatId: number,
+  role: MessageRecord['role'],
+  content: string,
+): Promise<MessageRecord> => {
+  const db = await getDatabase();
+  const now = new Date().toISOString();
+  const result = await db.executeSql(
+    'INSERT INTO messages (chat_id, role, content, created_at) VALUES (?, ?, ?, ?);',
+    [chatId, role, content, now],
+  );
+  await updateChatTimestamp(chatId);
+  const insertedId = result[0].insertId ?? 0;
+  const rows = await db.executeSql('SELECT * FROM messages WHERE id = ?;', [insertedId]);
+  return mapMessage(rows[0].rows.item(0));
+};
+
+export const bulkInsertMessages = async (
+  chatId: number,
+  messages: Array<{role: MessageRecord['role']; content: string; created_at?: string}>,
+) => {
+  const db = await getDatabase();
+  await db.transaction(async tx => {
+    for (const message of messages) {
+      const createdAt = message.created_at ?? new Date().toISOString();
+      await tx.executeSql(
+        'INSERT INTO messages (chat_id, role, content, created_at) VALUES (?, ?, ?, ?);',
+        [chatId, message.role, message.content, createdAt],
+      );
+    }
+  });
+  await updateChatTimestamp(chatId);
+};
+
+export const getMessagesForChat = async (chatId: number): Promise<MessageRecord[]> => {
+  const db = await getDatabase();
+  const result = await db.executeSql(
+    'SELECT * FROM messages WHERE chat_id = ? ORDER BY datetime(created_at) ASC;',
+    [chatId],
+  );
+  const rows = result[0].rows;
+  const items: MessageRecord[] = [];
+  for (let i = 0; i < rows.length; i += 1) {
+    items.push(mapMessage(rows.item(i)));
+  }
+  return items;
+};
+
+export const getLatestMessageForChat = async (
+  chatId: number,
+): Promise<MessageRecord | undefined> => {
+  const db = await getDatabase();
+  const result = await db.executeSql(
+    'SELECT * FROM messages WHERE chat_id = ? ORDER BY datetime(created_at) DESC LIMIT 1;',
+    [chatId],
+  );
+  if (result[0].rows.length === 0) {
+    return undefined;
+  }
+  return mapMessage(result[0].rows.item(0));
+};
+
+

--- a/src/storage/database.ts
+++ b/src/storage/database.ts
@@ -1,0 +1,47 @@
+import SQLite, {SQLiteDatabase} from 'react-native-sqlite-storage';
+
+SQLite.enablePromise(true);
+
+let database: SQLiteDatabase | null = null;
+
+const DATABASE_NAME = 'DealMaster.db';
+
+const createTables = async (db: SQLiteDatabase) => {
+  await db.executeSql(
+    `CREATE TABLE IF NOT EXISTS chats (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      title TEXT NOT NULL,
+      created_at TEXT DEFAULT (datetime('now')),
+      updated_at TEXT DEFAULT (datetime('now'))
+    );`,
+  );
+
+  await db.executeSql(
+    `CREATE TABLE IF NOT EXISTS messages (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      chat_id INTEGER NOT NULL,
+      role TEXT NOT NULL,
+      content TEXT NOT NULL,
+      created_at TEXT DEFAULT (datetime('now')),
+      FOREIGN KEY(chat_id) REFERENCES chats(id) ON DELETE CASCADE
+    );`,
+  );
+};
+
+export const getDatabase = async (): Promise<SQLiteDatabase> => {
+  if (database) {
+    return database;
+  }
+
+  database = await SQLite.openDatabase({name: DATABASE_NAME, location: 'default'});
+  await createTables(database);
+  return database;
+};
+
+export const closeDatabase = async () => {
+  if (database) {
+    await database.close();
+    database = null;
+  }
+};
+

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -1,0 +1,15 @@
+export type ChatRecord = {
+  id: number;
+  title: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type MessageRecord = {
+  id: number;
+  chat_id: number;
+  role: 'user' | 'assistant' | 'system' | 'summary';
+  content: string;
+  created_at: string;
+};
+

--- a/src/types/react-native-sqlite-storage.d.ts
+++ b/src/types/react-native-sqlite-storage.d.ts
@@ -1,0 +1,33 @@
+declare module 'react-native-sqlite-storage' {
+  export type ResultSet = {
+    insertId?: number;
+    rowsAffected: number;
+    rows: {
+      length: number;
+      item: (index: number) => any;
+    };
+  };
+
+  export type Transaction = {
+    executeSql: (
+      sqlStatement: string,
+      params?: any[],
+      success?: (transaction: Transaction, resultSet: ResultSet) => void,
+      error?: (transaction: Transaction, error: Error) => void,
+    ) => Promise<void>;
+  };
+
+  export type SQLiteDatabase = {
+    executeSql: (sqlStatement: string, params?: any[]) => Promise<[ResultSet]>;
+    transaction: (callback: (transaction: Transaction) => void) => Promise<void>;
+    close: () => Promise<void>;
+  };
+
+  const SQLite: {
+    enablePromise: (value: boolean) => void;
+    openDatabase: (options: {name: string; location: string}) => Promise<SQLiteDatabase>;
+  };
+
+  export default SQLite;
+}
+


### PR DESCRIPTION
## Summary
- add a SQLite-backed chat repository that creates chats/messages tables and exposes helpers
- add chat service logic for token-aware context building and summary generation
- add chat list and chat detail screens with one-tap summarization and navigation entry points

## Testing
- npm run typecheck
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8a21755f48321a4ce780d7453d138