### PR TITLE
Resolve conflicts for PR #17

### DIFF
--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -5,6 +5,7 @@ import LoginScreen from '../screens/LoginScreen';
 import HomeScreen from '../screens/HomeScreen';
 import SettingsScreen from '../screens/SettingsScreen';
 import ChatScreen from '../screens/ChatScreen';
+import ChatListScreen from '../screens/ChatListScreen';
 import {useAuthStore} from '../store/useAuthStore';
 import type {RootStackParamList} from './types';
 
@@ -19,7 +20,18 @@ const AppNavigator: React.FC = () => {
         {isAuthenticated ? (
           <>
             <Stack.Screen name="Home" component={HomeScreen} />
-            <Stack.Screen name="Chat" component={ChatScreen} />
+            <Stack.Screen
+              name="ChatList"
+              component={ChatListScreen}
+              options={{title: '對話列表'}}
+            />
+            <Stack.Screen
+              name="Chat"
+              component={ChatScreen}
+              options={({route}) => ({
+                title: route.params?.title ?? 'Chat',
+              })}
+            />
             <Stack.Screen name="Settings" component={SettingsScreen} />
           </>
         ) : (

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -1,6 +1,7 @@
 export type RootStackParamList = {
-  Login: undefined;
   Home: undefined;
+  ChatList: undefined;
+  Chat: {sessionId?: string; title?: string} | undefined;
   Settings: undefined;
-  Chat: undefined;
+  Login: undefined;
 };

--- a/src/screens/ChatListScreen.tsx
+++ b/src/screens/ChatListScreen.tsx
@@ -1,0 +1,222 @@
+import React, {useCallback, useState} from 'react';
+import type {NativeStackScreenProps} from '@react-navigation/native-stack';
+import {useFocusEffect} from '@react-navigation/native';
+import {
+  ActivityIndicator,
+  FlatList,
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import PrimaryButton from '../components/PrimaryButton';
+import {RootStackParamList} from '../navigation/types';
+import {chatMemory, type ChatSession} from '../services/chatMemory';
+import {colors} from '../theme/colors';
+
+const formatTimestamp = (timestamp: number): string => {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+  return date.toLocaleString();
+};
+
+type Props = NativeStackScreenProps<RootStackParamList, 'ChatList'>;
+
+const ChatListScreen: React.FC<Props> = ({navigation}) => {
+  const [sessions, setSessions] = useState<ChatSession[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  const loadSessions = useCallback(async () => {
+    setLoading(true);
+    try {
+      await chatMemory.initialize();
+      const data = await chatMemory.listSessions();
+      setSessions(data);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      loadSessions().catch(() => undefined);
+    }, [loadSessions]),
+  );
+
+  const handleCreateSession = useCallback(async () => {
+    await chatMemory.initialize();
+    const session = await chatMemory.createSession();
+    navigation.navigate('Chat', {
+      sessionId: session.id,
+      title: session.title,
+    });
+  }, [navigation]);
+
+  const handleSelectSession = useCallback(
+    (session: ChatSession) => {
+      navigation.navigate('Chat', {
+        sessionId: session.id,
+        title: session.title,
+      });
+    },
+    [navigation],
+  );
+
+  const handleDeleteSession = useCallback(async (sessionId: string) => {
+    await chatMemory.deleteSession(sessionId);
+    setSessions(prev => prev.filter(session => session.id !== sessionId));
+  }, []);
+
+  const renderItem = ({item}: {item: ChatSession}) => (
+    <TouchableOpacity
+      style={styles.sessionRow}
+      onPress={() => handleSelectSession(item)}
+      accessibilityRole="button">
+      <View style={styles.sessionHeader}>
+        <Text style={styles.sessionTitle}>{item.title}</Text>
+        <Text style={styles.sessionTimestamp}>{formatTimestamp(item.updatedAt)}</Text>
+      </View>
+      <Text style={styles.sessionPreview} numberOfLines={2}>
+        {item.messages
+          .filter(message => message.role !== 'system')
+          .map(message => message.content)
+          .join(' \u2022 ') || 'No messages yet.'}
+      </Text>
+      <TouchableOpacity
+        style={styles.deleteButton}
+        onPress={() => handleDeleteSession(item.id)}
+        accessibilityRole="button">
+        <Text style={styles.deleteText}>Delete</Text>
+      </TouchableOpacity>
+    </TouchableOpacity>
+  );
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.headerRow}>
+        <Text style={styles.title}>Chat History</Text>
+        <PrimaryButton title="New Chat" onPress={handleCreateSession} />
+      </View>
+      {loading ? (
+        <View style={styles.loader}>
+          <ActivityIndicator color={colors.primary} />
+        </View>
+      ) : (
+        <FlatList
+          data={sessions}
+          keyExtractor={item => item.id}
+          renderItem={renderItem}
+          contentContainerStyle={
+            sessions.length === 0 ? styles.emptyContainer : styles.listContent
+          }
+          ListEmptyComponent={
+            <View style={styles.emptyState}>
+              <Text style={styles.emptyTitle}>No chats yet</Text>
+              <Text style={styles.emptySubtitle}>
+                Start a new conversation to see it appear in your history.
+              </Text>
+            </View>
+          }
+        />
+      )}
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 20,
+    paddingTop: 24,
+    paddingBottom: 12,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  loader: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  listContent: {
+    paddingHorizontal: 20,
+    paddingBottom: 20,
+  },
+  emptyContainer: {
+    flexGrow: 1,
+    justifyContent: 'center',
+    paddingHorizontal: 20,
+  },
+  emptyState: {
+    alignItems: 'center',
+  },
+  emptyTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: colors.text,
+    marginBottom: 8,
+  },
+  emptySubtitle: {
+    fontSize: 14,
+    color: colors.muted,
+    textAlign: 'center',
+  },
+  sessionRow: {
+    backgroundColor: colors.white,
+    borderRadius: 16,
+    padding: 16,
+    marginBottom: 16,
+    shadowColor: colors.text,
+    shadowOffset: {width: 0, height: 4},
+    shadowOpacity: 0.08,
+    shadowRadius: 12,
+    elevation: 2,
+  },
+  sessionHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  sessionTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: colors.text,
+    flex: 1,
+    marginRight: 12,
+  },
+  sessionTimestamp: {
+    fontSize: 12,
+    color: colors.muted,
+  },
+  sessionPreview: {
+    fontSize: 14,
+    color: colors.muted,
+    marginBottom: 12,
+  },
+  deleteButton: {
+    alignSelf: 'flex-start',
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 12,
+    backgroundColor: '#fee2e2',
+  },
+  deleteText: {
+    color: colors.error,
+    fontWeight: '600',
+    fontSize: 12,
+  },
+});
+
+export default ChatListScreen;

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useCallback} from 'react';
 import type {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {
   ActivityIndicator,
@@ -15,6 +15,7 @@ import {useAuthStore} from '../store/useAuthStore';
 import {RootStackParamList} from '../navigation/types';
 import {useDeals} from '../hooks/useDeals';
 import type {Deal} from '../hooks/useDeals';
+import {chatMemory} from '../services/chatMemory';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Home'>;
 
@@ -25,6 +26,15 @@ const HomeScreen: React.FC<Props> = ({navigation}) => {
   const handleLogout = () => {
     logout();
   };
+
+  const handleStartChat = useCallback(async () => {
+    await chatMemory.initialize();
+    const session = await chatMemory.createSession();
+    navigation.navigate('Chat', {
+      sessionId: session.id,
+      title: session.title,
+    });
+  }, [navigation]);
 
   const renderItem = ({item}: {item: Deal}) => (
     <View style={styles.dealCard}>
@@ -50,8 +60,13 @@ const HomeScreen: React.FC<Props> = ({navigation}) => {
       </View>
       <PrimaryButton
         title="Ask DealMaster AI"
-        onPress={() => navigation.navigate('Chat')}
+        onPress={handleStartChat}
         style={styles.chatButton}
+      />
+      <PrimaryButton
+        title="View Chat History"
+        onPress={() => navigation.navigate('ChatList')}
+        style={styles.chatHistoryButton}
       />
       <FlatList
         data={deals}
@@ -122,6 +137,10 @@ const styles = StyleSheet.create({
     margin: 20,
   },
   chatButton: {
+    marginHorizontal: 20,
+    marginBottom: 16,
+  },
+  chatHistoryButton: {
     marginHorizontal: 20,
     marginBottom: 16,
   },

--- a/src/services/chatMemory.ts
+++ b/src/services/chatMemory.ts
@@ -1,0 +1,281 @@
+import type {ChatMessage} from '../ai/types';
+
+export interface ChatSession {
+  id: string;
+  title: string;
+  createdAt: number;
+  updatedAt: number;
+  messages: ChatMessage[];
+}
+
+const DEFAULT_SESSION_TITLE = 'New Chat';
+
+type SQLiteModule = typeof import('expo-sqlite') | null;
+
+type SQLResultSet = import('expo-sqlite').SQLResultSet;
+type WebSQLDatabase = import('expo-sqlite').WebSQLDatabase;
+
+type Adapter = {
+  initialize: () => Promise<void>;
+  listSessions: () => Promise<ChatSession[]>;
+  createSession: (title?: string) => Promise<ChatSession>;
+  getSession: (id: string) => Promise<ChatSession | null>;
+  saveMessages: (id: string, messages: ChatMessage[]) => Promise<void>;
+  updateSessionTitle: (id: string, title: string) => Promise<void>;
+  deleteSession: (id: string) => Promise<void>;
+};
+
+const createId = (): string =>
+  `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+
+const parseMessages = (serialized: unknown): ChatMessage[] => {
+  if (typeof serialized !== 'string' || serialized.length === 0) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(serialized);
+    if (Array.isArray(parsed)) {
+      return parsed as ChatMessage[];
+    }
+  } catch {
+    // Ignore malformed payloads and reset to an empty conversation.
+  }
+  return [];
+};
+
+let sqliteModule: SQLiteModule = null;
+try {
+  sqliteModule = require('expo-sqlite');
+} catch {
+  sqliteModule = null;
+}
+
+const hasSQLite = sqliteModule != null;
+
+const createSQLiteAdapter = (): Adapter => {
+  let database: WebSQLDatabase | null = null;
+
+  const getDatabase = (): WebSQLDatabase => {
+    if (!database) {
+      database = sqliteModule!.openDatabase('dealmaster-chat');
+    }
+    return database;
+  };
+
+  const runSql = async (
+    query: string,
+    params: (string | number | null)[] = [],
+  ): Promise<SQLResultSet> =>
+    new Promise((resolve, reject) => {
+      getDatabase().transaction(
+        tx => {
+          tx.executeSql(
+            query,
+            params,
+            (_transaction, result) => {
+              resolve(result);
+            },
+            (_transaction, error) => {
+              reject(error);
+              return false;
+            },
+          );
+        },
+        error => {
+          reject(error);
+        },
+      );
+    });
+
+  const initialize = async () => {
+    await runSql(
+      'CREATE TABLE IF NOT EXISTS chat_sessions (id TEXT PRIMARY KEY NOT NULL, title TEXT NOT NULL, messages TEXT NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)',
+    );
+  };
+
+  const listSessions = async (): Promise<ChatSession[]> => {
+    const result = await runSql(
+      'SELECT id, title, messages, created_at, updated_at FROM chat_sessions ORDER BY updated_at DESC',
+    );
+    const rows = result.rows as unknown as {length: number; item: (index: number) => any};
+    const sessions: ChatSession[] = [];
+    for (let index = 0; index < rows.length; index += 1) {
+      const row = rows.item(index) as Record<string, unknown>;
+      sessions.push({
+        id: String(row.id),
+        title: typeof row.title === 'string' && row.title.length > 0 ? row.title : DEFAULT_SESSION_TITLE,
+        createdAt: Number(row.created_at) || Date.now(),
+        updatedAt: Number(row.updated_at) || Date.now(),
+        messages: parseMessages(row.messages),
+      });
+    }
+    return sessions;
+  };
+
+  const getSession = async (id: string): Promise<ChatSession | null> => {
+    const result = await runSql(
+      'SELECT id, title, messages, created_at, updated_at FROM chat_sessions WHERE id = ? LIMIT 1',
+      [id],
+    );
+    const rows = result.rows as unknown as {length: number; item: (index: number) => any};
+    if (rows.length === 0) {
+      return null;
+    }
+    const row = rows.item(0) as Record<string, unknown>;
+    return {
+      id: String(row.id),
+      title:
+        typeof row.title === 'string' && row.title.length > 0
+          ? row.title
+          : DEFAULT_SESSION_TITLE,
+      createdAt: Number(row.created_at) || Date.now(),
+      updatedAt: Number(row.updated_at) || Date.now(),
+      messages: parseMessages(row.messages),
+    };
+  };
+
+  const createSession = async (title = DEFAULT_SESSION_TITLE): Promise<ChatSession> => {
+    const now = Date.now();
+    const id = createId();
+    await runSql(
+      'INSERT INTO chat_sessions (id, title, messages, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
+      [id, title, JSON.stringify([]), now, now],
+    );
+    return {
+      id,
+      title,
+      createdAt: now,
+      updatedAt: now,
+      messages: [],
+    };
+  };
+
+  const saveMessages = async (id: string, messages: ChatMessage[]) => {
+    const now = Date.now();
+    await runSql('UPDATE chat_sessions SET messages = ?, updated_at = ? WHERE id = ?', [
+      JSON.stringify(messages),
+      now,
+      id,
+    ]);
+  };
+
+  const updateSessionTitle = async (id: string, title: string) => {
+    const now = Date.now();
+    await runSql('UPDATE chat_sessions SET title = ?, updated_at = ? WHERE id = ?', [
+      title,
+      now,
+      id,
+    ]);
+  };
+
+  const deleteSession = async (id: string) => {
+    await runSql('DELETE FROM chat_sessions WHERE id = ?', [id]);
+  };
+
+  return {
+    initialize,
+    listSessions,
+    createSession,
+    getSession,
+    saveMessages,
+    updateSessionTitle,
+    deleteSession,
+  };
+};
+
+const createMemoryAdapter = (): Adapter => {
+  const sessions = new Map<string, ChatSession>();
+
+  const initialize = async () => {
+    // No-op for memory adapter.
+    if (sessions.size === 0) {
+      // Ensure at least deterministic behavior during tests by touching the map.
+      sessions.size;
+    }
+  };
+
+  const listSessions = async (): Promise<ChatSession[]> =>
+    Array.from(sessions.values()).sort((a, b) => b.updatedAt - a.updatedAt);
+
+  const createSession = async (title = DEFAULT_SESSION_TITLE): Promise<ChatSession> => {
+    const now = Date.now();
+    const session: ChatSession = {
+      id: createId(),
+      title,
+      createdAt: now,
+      updatedAt: now,
+      messages: [],
+    };
+    sessions.set(session.id, session);
+    return session;
+  };
+
+  const getSession = async (id: string): Promise<ChatSession | null> =>
+    sessions.get(id) ?? null;
+
+  const saveMessages = async (id: string, messages: ChatMessage[]) => {
+    const session = sessions.get(id);
+    if (!session) {
+      return;
+    }
+    session.messages = messages;
+    session.updatedAt = Date.now();
+    sessions.set(id, session);
+  };
+
+  const updateSessionTitle = async (id: string, title: string) => {
+    const session = sessions.get(id);
+    if (!session) {
+      return;
+    }
+    session.title = title;
+    session.updatedAt = Date.now();
+    sessions.set(id, session);
+  };
+
+  const deleteSession = async (id: string) => {
+    sessions.delete(id);
+  };
+
+  return {
+    initialize,
+    listSessions,
+    createSession,
+    getSession,
+    saveMessages,
+    updateSessionTitle,
+    deleteSession,
+  };
+};
+
+const adapter: Adapter = hasSQLite ? createSQLiteAdapter() : createMemoryAdapter();
+
+const deriveSessionTitle = (messages: ChatMessage[]): string => {
+  const firstUserMessage = messages.find(message => message.role === 'user');
+  if (!firstUserMessage) {
+    return DEFAULT_SESSION_TITLE;
+  }
+  const normalized = firstUserMessage.content.trim().replace(/\s+/g, ' ');
+  if (normalized.length === 0) {
+    return DEFAULT_SESSION_TITLE;
+  }
+  return normalized.length > 48 ? `${normalized.slice(0, 48)}…` : normalized;
+};
+
+export const chatMemory = {
+  initialize: adapter.initialize,
+  listSessions: adapter.listSessions,
+  createSession: adapter.createSession,
+  getSession: adapter.getSession,
+  deleteSession: adapter.deleteSession,
+  async saveConversation(id: string, messages: ChatMessage[]) {
+    await adapter.saveMessages(id, messages);
+  },
+  async updateTitle(id: string, messages: ChatMessage[]) {
+    const title = deriveSessionTitle(messages);
+    await adapter.updateSessionTitle(id, title);
+    return title;
+  },
+};
+
+export {DEFAULT_SESSION_TITLE};

--- a/src/types/expo-sqlite.d.ts
+++ b/src/types/expo-sqlite.d.ts
@@ -1,0 +1,43 @@
+declare module 'expo-sqlite' {
+  export interface SQLError {
+    code: number;
+    message: string;
+  }
+
+  export interface SQLResultSetRowList {
+    length: number;
+    item: (index: number) => any;
+    _array: any[];
+  }
+
+  export interface SQLResultSet {
+    insertId?: number;
+    rowsAffected: number;
+    rows: SQLResultSetRowList;
+  }
+
+  export interface SQLTransaction {
+    executeSql(
+      sqlStatement: string,
+      args?: (string | number | null)[],
+      callback?: (transaction: SQLTransaction, resultSet: SQLResultSet) => void,
+      errorCallback?: (transaction: SQLTransaction, error: SQLError) => boolean | void,
+    ): void;
+  }
+
+  export interface WebSQLDatabase {
+    transaction(
+      callback: (transaction: SQLTransaction) => void,
+      error?: (error: SQLError) => void,
+      success?: () => void,
+    ): void;
+  }
+
+  export function openDatabase(
+    name?: string,
+    version?: string,
+    description?: string,
+    size?: number,
+    callback?: () => void,
+  ): WebSQLDatabase;
+}


### PR DESCRIPTION
## Summary
- add ChatList screen and navigation routes so authenticated users can browse chat history
- persist GPT-5 chat sessions with a SQLite-backed chatMemory service while retaining streaming behaviour
- refresh Home and Chat screens to integrate session creation, history access, and title management

## Testing
- npm run typecheck
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9314754208321a1185947bd2fe6cb