### PR TITLE
Fix expo-sqlite module detection

### DIFF
--- a/src/services/chatMemory.ts
+++ b/src/services/chatMemory.ts
@@ -45,7 +45,17 @@ const parseMessages = (serialized: unknown): ChatMessage[] => {
 
 let sqliteModule: SQLiteModule = null;
 try {
-  sqliteModule = require('expo-sqlite');
+  const requiredModule = require('expo-sqlite');
+  if (requiredModule && typeof requiredModule.openDatabase === 'function') {
+    sqliteModule = requiredModule as SQLiteModule;
+  } else if (
+    requiredModule?.default &&
+    typeof requiredModule.default.openDatabase === 'function'
+  ) {
+    sqliteModule = requiredModule.default as SQLiteModule;
+  } else {
+    sqliteModule = null;
+  }
 } catch {
   sqliteModule = null;
 }


### PR DESCRIPTION
## Summary
- normalize the expo-sqlite require logic to support either CommonJS or default exports when loading the module for chat memory persistence

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db666a89cc832184e67039cff573d5