### PR TITLE
fix: enforce shared chat/OCR monthly quota

### DIFF
--- a/src/components/UpgradeModal.tsx
+++ b/src/components/UpgradeModal.tsx
@@ -31,8 +31,8 @@ const UpgradeModal: React.FC<Props> = ({visible, plan, onClose, onUpgrade}) => {
           </Text>
           <Text style={styles.description}>
             {plan === 'pro'
-              ? 'Thanks for supporting DealMaster! Enjoy unlimited chats and exclusive deal alerts.'
-              : 'Unlock unlimited AI chats and priority deal alerts with the Pro plan. Stay ahead with the best savings delivered instantly.'}
+              ? 'Thanks for supporting DealMaster! Enjoy unlimited chats, OCR extractions, and exclusive deal alerts. Chat and OCR share the same quota, and yours is unlimited.'
+              : 'Unlock unlimited AI chats, OCR extractions, and priority deal alerts with the Pro plan. Chat and OCR share the same monthly quota on Free, so upgrade to keep the insights flowing.'}
           </Text>
           {plan !== 'pro' ? (
             <PrimaryButton title="Upgrade now" onPress={onUpgrade} style={styles.ctaButton} />

--- a/src/screens/ChatScreen.tsx
+++ b/src/screens/ChatScreen.tsx
@@ -23,7 +23,7 @@ import {chatSessionsService} from '../services/chatSessions';
 import {pickImage, extractTextFromImage} from '../ai/ocr';
 import {useSubscriptionStore} from '../store/useSubscriptionStore';
 import UpgradeModal from '../components/UpgradeModal';
-import {track} from '../services/telemetry';
+import {track as trackEvent} from '../services/telemetry';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Chat'>;
 
@@ -352,7 +352,7 @@ const ChatScreen: React.FC<Props> = ({route, navigation}) => {
 
   const handleStartOcr = useCallback(async () => {
     if (!canUseOcr()) {
-      track('quota_block', {feature: 'ocr'});
+      trackEvent('quota_block', {feature: 'ocr'});
       openUpgradeModal();
       return;
     }

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -127,11 +127,11 @@ const SettingsScreen: React.FC<Props> = ({navigation}) => {
           </Text>
           <Text style={styles.subscriptionUsage}>
             {plan === 'pro'
-              ? 'Unlimited AI chats and real-time deal alerts.'
-              : `Used ${usedQuota} of ${monthlyQuota} free AI requests this month.`}
+              ? 'Unlimited AI chats, OCR extractions, and real-time deal alerts.'
+              : `Used ${usedQuota} of ${monthlyQuota} free chat/OCR requests this month.`}
           </Text>
           <Text style={styles.subscriptionHint}>
-            Your quota refreshes on the first day of every month.
+            Chat and OCR share the same monthly quota, which refreshes on the first day of every month.
           </Text>
           {plan === 'free' ? (
             <PrimaryButton

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -1,0 +1,15 @@
+declare const __DEV__: boolean;
+
+export type TelemetryPayload = Record<string, unknown> | undefined;
+
+export const track = (event: string, payload?: TelemetryPayload): void => {
+  try {
+    // In production this can be replaced with a real analytics sink.
+    console.log(`[telemetry] ${event}`, payload ?? {});
+  } catch (error) {
+    // Swallow logging errors to avoid interrupting user flows.
+    if (typeof __DEV__ !== 'undefined' && __DEV__) {
+      console.warn('Failed to emit telemetry event', error);
+    }
+  }
+};

--- a/src/subscription/limits.ts
+++ b/src/subscription/limits.ts
@@ -1,0 +1,64 @@
+import type {SubscriptionPlan} from './types';
+
+export const MONTHLY_FREE_QUOTA = 3;
+export const MONTHLY_PRO_QUOTA = 1_000_000;
+
+export const PLAN_MONTHLY_QUOTAS: Record<SubscriptionPlan, number> = {
+  free: MONTHLY_FREE_QUOTA,
+  pro: MONTHLY_PRO_QUOTA,
+};
+
+export const getMonthlyQuotaForPlan = (plan: SubscriptionPlan): number =>
+  PLAN_MONTHLY_QUOTAS[plan];
+
+export const isUnlimitedPlan = (plan: SubscriptionPlan): boolean => plan === 'pro';
+
+export const canUseChat = (
+  plan: SubscriptionPlan,
+  usedQuota: number,
+  monthlyQuota: number,
+): boolean => {
+  if (isUnlimitedPlan(plan)) {
+    return true;
+  }
+  return usedQuota < monthlyQuota;
+};
+
+export const canUseOcr = canUseChat;
+
+const normalizeAmount = (amount: number | undefined): number => {
+  if (typeof amount !== 'number' || !Number.isFinite(amount) || amount <= 0) {
+    return 0;
+  }
+  return amount;
+};
+
+const applyConsumption = (
+  plan: SubscriptionPlan,
+  usedQuota: number,
+  monthlyQuota: number,
+  amount?: number,
+): number => {
+  if (isUnlimitedPlan(plan)) {
+    return usedQuota;
+  }
+  const normalized = normalizeAmount(amount);
+  if (normalized === 0) {
+    return usedQuota;
+  }
+  return Math.min(monthlyQuota, usedQuota + normalized);
+};
+
+export const onChatConsumed = (
+  plan: SubscriptionPlan,
+  usedQuota: number,
+  monthlyQuota: number,
+  amount?: number,
+): number => applyConsumption(plan, usedQuota, monthlyQuota, amount);
+
+export const onOcrConsumed = (
+  plan: SubscriptionPlan,
+  usedQuota: number,
+  monthlyQuota: number,
+  amount?: number,
+): number => applyConsumption(plan, usedQuota, monthlyQuota, amount);

--- a/src/subscription/types.ts
+++ b/src/subscription/types.ts
@@ -1,0 +1,1 @@
+export type SubscriptionPlan = 'free' | 'pro';

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -32,4 +32,5 @@ export interface ChatScreenParams {
   sessionId?: string;
   title?: string;
   pendingMessage?: string;
+  pendingMessageSource?: 'ocr' | 'user';
 }


### PR DESCRIPTION
## Summary
- add a shared subscription limits module and expose chat/OCR quota helpers in the store
- guard chat and OCR flows with canUse checks, consume OCR usage on confirmation, and surface upgrade messaging updates
- emit telemetry events for OCR quota consumption/blocks and refresh UI copy to explain the combined quota

## Testing
- npm run typecheck
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ddec9755388321bf347ab946c2cf8e