### PR TITLE
Add runtime-flagged native OCR providers

### DIFF
--- a/src/ai/ocr.ts
+++ b/src/ai/ocr.ts
@@ -1,6 +1,8 @@
 import {Alert, Platform} from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 
+import {getOcrProvider} from './ocr/provider';
+
 export type PickedImage = {
   uri: string;
   width: number;
@@ -76,8 +78,9 @@ export const pickImage = async (): Promise<PickedImage | null> => {
   return normalizeAsset(result.assets[0]);
 };
 
-export async function extractTextFromImage(_uri: string): Promise<string> {
-  return '';
+export async function extractTextFromImage(uri: string): Promise<string> {
+  const provider = getOcrProvider();
+  return provider.extractText(uri);
 }
 
 export default extractTextFromImage;

--- a/src/ai/ocr/androidProvider.ts
+++ b/src/ai/ocr/androidProvider.ts
@@ -1,0 +1,48 @@
+import type {OcrProvider} from './provider';
+
+type MlKitModule = {
+  recognize: (uri: string) => Promise<unknown>;
+};
+
+const loadMlKitModule = async (): Promise<MlKitModule | null> => {
+  try {
+    const mlkitModule = await Promise.resolve().then(() => require('expo-mlkit-ocr'));
+    if (mlkitModule && typeof mlkitModule.recognize === 'function') {
+      return mlkitModule as MlKitModule;
+    }
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.debug('[OCR][Android] Native ML Kit module unavailable.', error);
+    }
+  }
+
+  return null;
+};
+
+export const createAndroidProvider = (): OcrProvider => ({
+  async extractText(uri: string): Promise<string> {
+    try {
+      const module = await loadMlKitModule();
+      if (!module) {
+        return '';
+      }
+
+      // TODO: Hook up ML Kit text recognition when the native module is available.
+      const result = await module.recognize(uri);
+      if (
+        result &&
+        typeof result === 'object' &&
+        'text' in result &&
+        typeof (result as {text?: unknown}).text === 'string'
+      ) {
+        return (result as {text: string}).text;
+      }
+    } catch (error) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.debug('[OCR][Android] Failed to extract text.', error);
+      }
+    }
+
+    return '';
+  },
+});

--- a/src/ai/ocr/iosProvider.ts
+++ b/src/ai/ocr/iosProvider.ts
@@ -1,0 +1,48 @@
+import type {OcrProvider} from './provider';
+
+type VisionKitModule = {
+  recognizeTextFromImage: (uri: string) => Promise<unknown>;
+};
+
+const loadVisionKitModule = async (): Promise<VisionKitModule | null> => {
+  try {
+    const visionKitModule = await Promise.resolve().then(() => require('expo-mlkit-ocr'));
+    if (visionKitModule && typeof visionKitModule.recognizeTextFromImage === 'function') {
+      return visionKitModule as VisionKitModule;
+    }
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.debug('[OCR][iOS] Native VisionKit module unavailable.', error);
+    }
+  }
+
+  return null;
+};
+
+export const createIosProvider = (): OcrProvider => ({
+  async extractText(uri: string): Promise<string> {
+    try {
+      const module = await loadVisionKitModule();
+      if (!module) {
+        return '';
+      }
+
+      // TODO: Wire up actual VisionKit OCR integration when the native module is available.
+      const result = await module.recognizeTextFromImage(uri);
+      if (
+        result &&
+        typeof result === 'object' &&
+        'text' in result &&
+        typeof (result as {text?: unknown}).text === 'string'
+      ) {
+        return (result as {text: string}).text;
+      }
+    } catch (error) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.debug('[OCR][iOS] Failed to extract text.', error);
+      }
+    }
+
+    return '';
+  },
+});

--- a/src/ai/ocr/provider.ts
+++ b/src/ai/ocr/provider.ts
@@ -1,0 +1,81 @@
+import {Platform} from 'react-native';
+
+import {flags} from '../../config/featureFlags';
+
+export type OcrProvider = {
+  extractText: (uri: string) => Promise<string>;
+};
+
+const stubProvider: OcrProvider = {
+  async extractText() {
+    return '';
+  },
+};
+
+let cachedProvider: OcrProvider | null = null;
+
+const loadIosProvider = (): OcrProvider | null => {
+  try {
+    const {createIosProvider} = require('./iosProvider');
+    if (typeof createIosProvider === 'function') {
+      return createIosProvider();
+    }
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.debug('[OCR] Unable to load iOS provider. Falling back to stub.', error);
+    }
+  }
+
+  return null;
+};
+
+const loadAndroidProvider = (): OcrProvider | null => {
+  try {
+    const {createAndroidProvider} = require('./androidProvider');
+    if (typeof createAndroidProvider === 'function') {
+      return createAndroidProvider();
+    }
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.debug('[OCR] Unable to load Android provider. Falling back to stub.', error);
+    }
+  }
+
+  return null;
+};
+
+export const getOcrProvider = (): OcrProvider => {
+  if (cachedProvider) {
+    return cachedProvider;
+  }
+
+  if (!flags.ocrNative) {
+    cachedProvider = stubProvider;
+    return cachedProvider;
+  }
+
+  if (Platform.OS === 'ios') {
+    const provider = loadIosProvider();
+    if (provider) {
+      cachedProvider = provider;
+      return provider;
+    }
+  }
+
+  if (Platform.OS === 'android') {
+    const provider = loadAndroidProvider();
+    if (provider) {
+      cachedProvider = provider;
+      return provider;
+    }
+  }
+
+  cachedProvider = stubProvider;
+  return cachedProvider;
+};
+
+export const __TESTING__ = {
+  stubProvider,
+  loadIosProvider,
+  loadAndroidProvider,
+};

--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -1,0 +1,74 @@
+export type FeatureFlags = {
+  ocrNative: boolean;
+};
+
+const readEnvFlag = (): boolean | undefined => {
+  if (typeof process === 'undefined' || !process?.env) {
+    return undefined;
+  }
+
+  const candidates = [
+    process.env.EXPO_PUBLIC_OCR_NATIVE,
+    process.env.OCR_NATIVE,
+    process.env.REACT_NATIVE_OCR_NATIVE,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string') {
+      const normalized = candidate.trim().toLowerCase();
+      if (['1', 'true', 'yes', 'on'].includes(normalized)) {
+        return true;
+      }
+      if (['0', 'false', 'no', 'off'].includes(normalized)) {
+        return false;
+      }
+    }
+  }
+
+  return undefined;
+};
+
+const readExtraFlag = (): boolean | undefined => {
+  try {
+    const Constants = require('expo-constants');
+    const extra =
+      Constants?.expoConfig?.extra ?? Constants?.manifest?.extra ?? Constants?.expoGoConfig?.extra;
+    const value = extra?.ocrNative;
+    if (typeof value === 'boolean') {
+      return value;
+    }
+    if (typeof value === 'string') {
+      const normalized = value.trim().toLowerCase();
+      if (['1', 'true', 'yes', 'on'].includes(normalized)) {
+        return true;
+      }
+      if (['0', 'false', 'no', 'off'].includes(normalized)) {
+        return false;
+      }
+    }
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.debug('[Flags] Unable to read expo extra configuration.', error);
+    }
+  }
+
+  return undefined;
+};
+
+const resolveFlag = (): boolean => {
+  const envValue = readEnvFlag();
+  if (typeof envValue === 'boolean') {
+    return envValue;
+  }
+
+  const extraValue = readExtraFlag();
+  if (typeof extraValue === 'boolean') {
+    return extraValue;
+  }
+
+  return false;
+};
+
+export const flags: FeatureFlags = {
+  ocrNative: resolveFlag(),
+};


### PR DESCRIPTION
## Summary
- add feature flag plumbing to control native OCR usage
- introduce provider selection with safe fallbacks and platform-specific skeletons
- route OCR extraction through provider lookup while defaulting to stub behavior

## Testing
- npm run lint
- npm run typecheck

## Notes
- iOS/Android local enablement: `npx expo install expo-mlkit-ocr expo-image-picker` (or integrate the chosen VisionKit/ML Kit native module) before enabling the flag.
- After installing native bits, enable locally via `app.json` (`{"expo":{"extra":{"ocrNative":true}}}`) or environment variable `EXPO_PUBLIC_OCR_NATIVE=true`/`OCR_NATIVE=true`.
- Run `npx expo prebuild` locally after installing native dependencies to sync native projects.


------
https://chatgpt.com/codex/tasks/task_e_68ddeca10928832197973eb6ff6cabad