### PR TITLE
Fix OCR provider integration

### DIFF
--- a/src/ai/ocr.ts
+++ b/src/ai/ocr.ts
@@ -1,7 +1,7 @@
 import {Alert, Platform} from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
-import type {OcrProvider, OcrResult} from './ocr/provider';
-import stubProvider from './ocr/stubProvider';
+import {getOcrProvider} from './ocr/provider';
+import type {OcrResult} from './ocr/provider';
 
 export type PickedImage = {
   uri: string;
@@ -78,18 +78,11 @@ export const pickImage = async (): Promise<PickedImage | null> => {
   return normalizeAsset(result.assets[0]);
 };
 
-let provider: OcrProvider = stubProvider;
-
-export const setOcrProvider = (next: OcrProvider) => {
-  provider = next;
-};
-
-export const getOcrProvider = (): OcrProvider => provider;
-
 export async function extractTextFromImage(uri: string): Promise<OcrResult> {
-  return provider.extractTextFromImage(uri);
+  return getOcrProvider().extractTextFromImage(uri);
 }
 
 export default extractTextFromImage;
 
+export {setOcrProvider, getOcrProvider} from './ocr/provider';
 export type {OcrProvider, OcrResult} from './ocr/provider';

--- a/src/ai/ocr/provider.ts
+++ b/src/ai/ocr/provider.ts
@@ -1,3 +1,5 @@
+import stubProvider from './stubProvider';
+
 export type OcrResult = {
   text: string;
   meta?: Record<string, any>;
@@ -6,3 +8,11 @@ export type OcrResult = {
 export interface OcrProvider {
   extractTextFromImage(localUri: string): Promise<OcrResult>;
 }
+
+let provider: OcrProvider = stubProvider;
+
+export const setOcrProvider = (next: OcrProvider) => {
+  provider = next;
+};
+
+export const getOcrProvider = (): OcrProvider => provider;


### PR DESCRIPTION
## Summary
- route `extractTextFromImage` through the active OCR provider
- move provider registration logic into `src/ai/ocr/provider.ts` with the stub default

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68df8ef13ebc83218d76433a46868ba9