### PR TITLE
chore(flags): declare expo-constants dep and keep safe require

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@react-navigation/native-stack": "^6.9.17",
     "@react-native-async-storage/async-storage": "file:vendor/@react-native-async-storage/async-storage",
     "axios": "^1.6.7",
+    "expo-constants": "^15.0.0",
     "expo-image-picker": "^15.0.7",
     "react": "18.2.0",
     "react-native": "0.72.10",


### PR DESCRIPTION
## Summary
- Add expo-constants as an app dependency so Metro can resolve the module when loading flags
- Guard the dynamic require for expo-constants to avoid crashes when the module is unavailable

## Testing
- npm run typecheck
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df9427a8648321a2743e8c1fee759a