### PR TITLE
Update package-lock.json for expo-constants dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@react-navigation/native": "^6.1.9",
         "@react-navigation/native-stack": "^6.9.17",
         "axios": "^1.6.7",
+        "expo-constants": "^15.4.6",
         "expo-image-picker": "^15.0.7",
         "react": "18.2.0",
         "react-native": "0.72.10",
@@ -6244,6 +6245,12 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/expo-constants": {
+      "version": "15.4.6",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-image-picker": {


### PR DESCRIPTION
## Summary
- run npm install to resync the lockfile with package.json
- ensure the new expo-constants dependency is captured in package-lock.json

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df970d63ec8321b74101665acb98ad