### PR TITLE
Fix lint workflow env configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,6 @@ jobs:
         run: npm run typecheck
 
       - name: Lint
+        env:
+          ESLINT_USE_FLAT_CONFIG: false
         run: npm run lint -- --max-warnings=0


### PR DESCRIPTION
## Summary
- ensure the lint job sets `ESLINT_USE_FLAT_CONFIG` to false while keeping the strict lint command

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dfbe77ae9483219587f719d1b5d43f