### PR TITLE
Align speech telemetry payloads with schema

### DIFF
--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -2,7 +2,7 @@ import type {SttTelemetryEvent, SttTelemetryPayload} from '../types/telemetry';
 
 declare const __DEV__: boolean;
 
-export type TelemetryPayload = Record<string, unknown> | undefined;
+export type TelemetryPayload = object | undefined;
 
 export const track = (event: string, payload?: TelemetryPayload): void => {
   try {


### PR DESCRIPTION
## Summary
- normalize speech telemetry payloads to include required platform and provider metadata
- shape STT event payloads per documented schema and normalize emitted error codes
- relax generic telemetry payload typing to accept structured STT payload objects

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dfc9cd875c8321abc8c2924b6dc16a