### PR TITLE
fix(types): align STT telemetry payloads with schema

### DIFF
--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -1,4 +1,4 @@
-import type {SttTelemetryEvent, SttTelemetryPayload} from '../types/telemetry';
+import type {SttTelemetryEvent, SttTelemetryPayloadFor} from '../types/telemetry';
 
 declare const __DEV__: boolean;
 
@@ -16,9 +16,9 @@ export const track = (event: string, payload?: TelemetryPayload): void => {
   }
 };
 
-export const trackSttEvent = (
-  event: SttTelemetryEvent,
-  payload: SttTelemetryPayload,
+export const trackSttEvent = <E extends SttTelemetryEvent>(
+  event: E,
+  payload: SttTelemetryPayloadFor<E>,
 ): void => {
   track(event, payload);
 };


### PR DESCRIPTION
## Summary
- remove reliance on non-schema speech payload fields and normalize telemetry error codes inside the speech service
- map Android speech recognizer codes to shared NormalizedErrorCode values when emitting STT telemetry
- tighten telemetry tracking generics so each STT event enforces its schema-compliant payload

## Testing
- npm run typecheck
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dfd8a05f8483218b2ce75963a45eb1