### PR TITLE
chore(ci): stabilize lint workflow env config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
+          cache-dependency-path: package-lock.json
 
       - name: Install dependencies
         run: npm ci
@@ -26,5 +27,5 @@ jobs:
 
       - name: Lint
         env:
-          ESLINT_USE_FLAT_CONFIG: false
-        run: npm run lint -- --max-warnings=0
+          ESLINT_USE_FLAT_CONFIG: '0'
+        run: npm run lint -- --max-warnings=0 --config .eslintrc.js


### PR DESCRIPTION
## Summary
- add package-lock.json as the npm cache key for the CI workflow
- force ESLint to use the legacy config by exporting ESLINT_USE_FLAT_CONFIG=0 and explicitly targeting .eslintrc.js

## Testing
- npm run lint -- --max-warnings=0 --config .eslintrc.js

------
https://chatgpt.com/codex/tasks/task_e_68dfd8c6a1d08321aef7b1c775e0d166