### PR TITLE
feat(ios): speech-to-text bridge + telemetry parity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@
 !/android/app/src/main/java/com/dealmaster/SpeechModule.kt
 !/android/app/src/main/java/com/dealmaster/SpeechPackage.kt
 /ios
+!/ios/Dealmaster/
+!/ios/Dealmaster/Speech/
+!/ios/Dealmaster/Speech/SpeechModule.swift
+!/ios/Dealmaster/Speech/SpeechModuleBridge.m
 /expo
 
 # Logs

--- a/README.md
+++ b/README.md
@@ -82,6 +82,70 @@ subscription();
 
 - Call `requestPermission()` before recording so the module can prompt users at runtime. When a user permanently denies access the module emits the `stt_permission_denied` telemetry event and resolves with a `blocked` status.
 
+### iOS-specific setup
+
+- Expo apps automatically merge the `ios.infoPlist` entries declared in [`app.json`](app.json); ensure the microphone and speech recognition usage descriptions are present before submitting to the App Store.
+- No extra React Native registration is required — the Swift bridge is exported through `SpeechModuleBridge.m` and is available as `NativeModules.SpeechModule`.
+- For local development run `npx pod-install` after installing JavaScript dependencies so the native module is compiled into the iOS project.
+
+### Testing notes
+
+- **Permissions** – Use `requestPermission()` to trigger the native prompt. On the iOS Simulator you can script responses with:
+
+  ```bash
+  xcrun simctl privacy booted speech-recognition grant com.dealmaster
+  xcrun simctl privacy booted speech-recognition deny com.dealmaster
+  xcrun simctl privacy booted microphone grant com.dealmaster
+  xcrun simctl privacy booted microphone deny com.dealmaster
+  ```
+
+- **Microphone input** – Feed canned audio to the simulator microphone while testing partial/final events:
+
+  ```bash
+  xcrun simctl io booted microphone ./fixtures/sample-command.wav
+  ```
+
+  End the stream with `Ctrl+C` once you observe `stt_final` firing.
+
+- **Telemetry expectations** – Example payloads emitted via `trackSttEvent`:
+
+  ```ts
+  // stt_partial
+  {
+    platform: 'ios',
+    provider: 'native',
+    sequence_id: 1,
+    text_length: 12,
+    partial_transcript: 'turn on lights',
+  }
+
+  // stt_final
+  {
+    platform: 'ios',
+    provider: 'native',
+    duration_ms: 3250,
+    text_length: 12,
+    transcript: 'turn on lights',
+  }
+
+  // stt_error
+  {
+    platform: 'ios',
+    provider: 'native',
+    error_code: 'no_speech_detected',
+    message: 'SFSpeechErrorCode.noSpeech',
+    native_flag: true,
+  }
+
+  // stt_permission_denied
+  {
+    platform: 'ios',
+    provider: 'native',
+    error_code: 'permission_denied',
+    native_flag: true,
+  }
+  ```
+
 ## Environment Variables
 
 Copy `.env.example` to `.env` and update the `API_URL` value to point to your backend service. The value will be used when creating the Axios instance.

--- a/app.json
+++ b/app.json
@@ -2,6 +2,12 @@
   "name": "dealmaster",
   "displayName": "DealMaster",
   "expo": {
-    "plugins": ["expo-image-picker"]
+    "plugins": ["expo-image-picker"],
+    "ios": {
+      "infoPlist": {
+        "NSMicrophoneUsageDescription": "Allow DealMaster to capture voice input for speech-to-text commands.",
+        "NSSpeechRecognitionUsageDescription": "Allow DealMaster to transcribe your speech to text inside the assistant."
+      }
+    }
   }
 }

--- a/ios/Dealmaster/Speech/SpeechModuleBridge.m
+++ b/ios/Dealmaster/Speech/SpeechModuleBridge.m
@@ -1,0 +1,21 @@
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
+
+@interface RCT_EXTERN_MODULE(SpeechModule, RCTEventEmitter)
+
+RCT_EXTERN_METHOD(startTranscribing:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(stopTranscribing:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(cancelTranscribing:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(getPermissionStatus:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(requestPermission:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+@end


### PR DESCRIPTION
## Summary
- add a Swift speech-to-text module with normalized error events, permission checks, and user cancel handling to match Android parity
- expose the native bridge, update Expo Info.plist permissions, and allow iOS sources through .gitignore
- document iOS setup, simulator testing flows, and sample telemetry payloads for QA

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dfd8b017248321ba5b1f07b6c8f0fb