### PR TITLE
Fix ESLint config toggle in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,5 @@ jobs:
 
       - name: Lint
         env:
-          ESLINT_USE_FLAT_CONFIG: '0'
+          ESLINT_USE_FLAT_CONFIG: 'false'
         run: npm run lint -- --max-warnings=0 --config .eslintrc.js


### PR DESCRIPTION
## Summary
- ensure the CI lint step disables ESLint flat config mode explicitly

## Testing
- ESLINT_USE_FLAT_CONFIG=false npm run lint -- --max-warnings=0 --config .eslintrc.js

------
https://chatgpt.com/codex/tasks/task_e_68e098b786408321a3f45ccd229d76f3