### PR TITLE
Fix lint workflow warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,4 +28,5 @@ jobs:
       - name: Lint
         env:
           ESLINT_USE_FLAT_CONFIG: 'false'
+          TSESTREE_NO_WARN_ON_UNSUPPORTED_TYPESCRIPT_VERSION: '1'
         run: npm run lint -- --max-warnings=0 --config .eslintrc.js


### PR DESCRIPTION
## Summary
- silence the unsupported TypeScript version warning during the lint step by setting the TSESTREE_NO_WARN_ON_UNSUPPORTED_TYPESCRIPT_VERSION flag

## Testing
- npm run lint -- --max-warnings=0 --config .eslintrc.js

------
https://chatgpt.com/codex/tasks/task_e_68e0a3af44b08321a1661ef902c6d9b1