### PR TITLE
Align native speech telemetry payloads across platforms

### DIFF
--- a/src/services/speech.ts
+++ b/src/services/speech.ts
@@ -25,14 +25,18 @@ type TranscriptionEvent = {
 
 type ErrorEvent = {
   message?: string;
-  error_code?: string | number | null;
+  error_code: string;
+};
+
+type PermissionDeniedEvent = {
+  error_code: 'permission_denied';
 };
 
 export type SpeechEventPayloadMap = {
   stt_partial: TranscriptionEvent;
   stt_final: TranscriptionEvent;
   stt_error: ErrorEvent;
-  stt_permission_denied: Record<string, never>;
+  stt_permission_denied: PermissionDeniedEvent;
 };
 
 export type SpeechEventName = keyof SpeechEventPayloadMap;
@@ -181,7 +185,7 @@ if (eventEmitter && nativeModule) {
   });
 
   eventEmitter.addListener('stt_permission_denied', payload => {
-    handleNativeEvent('stt_permission_denied', payload as Record<string, never>);
+    handleNativeEvent('stt_permission_denied', payload as PermissionDeniedEvent);
   });
 }
 


### PR DESCRIPTION
## Summary
- normalize Android speech bridge telemetry payloads, emit permission error metadata, and reject promises with JSON-formatted error details
- update the iOS speech module to mirror the Android payload structure and return JSON error strings for consumer parsing
- tighten React Native speech service typings for the unified event payloads

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e1c220bfb88321bbbb6c753c6a9296