### PR TITLE
Add retry handling and telemetry reporting for iOS speech

### DIFF
--- a/src/services/__tests__/speech-error-telemetry.test.js
+++ b/src/services/__tests__/speech-error-telemetry.test.js
@@ -1,0 +1,77 @@
+const mockTrackSttEvent = jest.fn();
+const mockNormalizeTelemetryErrorCode = jest.fn(code => code);
+
+const mockListeners = {};
+const mockAddListener = jest.fn((event, handler) => {
+  if (!mockListeners[event]) {
+    mockListeners[event] = [];
+  }
+  mockListeners[event].push(handler);
+  return {remove: jest.fn()};
+});
+
+jest.mock('react-native', () => ({
+  NativeModules: {
+    SpeechModule: {
+      startTranscribing: jest.fn(),
+      stopTranscribing: jest.fn(),
+      cancelTranscribing: jest.fn(),
+      getPermissionStatus: jest.fn(),
+      requestPermission: jest.fn(),
+    },
+  },
+  NativeEventEmitter: jest.fn().mockImplementation(() => ({
+    addListener: mockAddListener,
+  })),
+  Platform: {OS: 'ios'},
+  __listeners: mockListeners,
+}));
+
+jest.mock('../telemetry', () => ({
+  trackSttEvent: (...args) => mockTrackSttEvent(...args),
+  normalizeTelemetryErrorCode: code => mockNormalizeTelemetryErrorCode(code),
+}));
+
+describe('speech native error telemetry', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    Object.keys(mockListeners).forEach(key => {
+      mockListeners[key] = [];
+    });
+    mockNormalizeTelemetryErrorCode.mockImplementation(code => code);
+  });
+
+  it('reports retry metadata when native error events occur', () => {
+    jest.isolateModules(() => {
+      require('../speech');
+    });
+
+    const reactNative = require('react-native');
+    const errorListeners = reactNative.__listeners['stt_error'];
+    expect(errorListeners).toBeDefined();
+    expect(errorListeners.length).toBeGreaterThan(0);
+
+    const payload = {
+      error_code: 'timeout',
+      message: 'Network unstable',
+      retry_count: 2,
+      will_retry: true,
+    };
+
+    errorListeners.forEach(listener => listener(payload));
+
+    expect(mockTrackSttEvent).toHaveBeenCalledWith(
+      'stt_error',
+      expect.objectContaining({
+        error_code: 'timeout',
+        message: 'Network unstable',
+        retry_count: 2,
+        will_retry: true,
+        native_flag: true,
+        provider: 'native',
+        platform: 'ios',
+      }),
+    );
+  });
+});

--- a/src/services/speech.ts
+++ b/src/services/speech.ts
@@ -26,6 +26,8 @@ type TranscriptionEvent = {
 type ErrorEvent = {
   message?: string;
   error_code: string;
+  retry_count?: number;
+  will_retry?: boolean;
 };
 
 type PermissionDeniedEvent = {
@@ -130,6 +132,12 @@ const emitTelemetry = <E extends SpeechEventName>(
       };
       if (typeof errorPayload.message === 'string') {
         telemetry.message = errorPayload.message;
+      }
+      if (typeof errorPayload.retry_count === 'number') {
+        telemetry.retry_count = errorPayload.retry_count;
+      }
+      if (typeof errorPayload.will_retry === 'boolean') {
+        telemetry.will_retry = errorPayload.will_retry;
       }
       trackSttEvent('stt_error', telemetry);
       return;

--- a/src/types/telemetry.ts
+++ b/src/types/telemetry.ts
@@ -47,6 +47,8 @@ export interface SttErrorTelemetryPayload extends BaseTelemetryProps {
   error_code: NormalizedErrorCode;
   message?: string;
   native_flag?: boolean;
+  retry_count?: number;
+  will_retry?: boolean;
 }
 
 export interface SttPermissionDeniedTelemetryPayload extends BaseTelemetryProps {


### PR DESCRIPTION
## Summary
- add automatic retry handling in the iOS speech module with telemetry metadata and session cleanup
- include retry metadata in speech error telemetry payloads on the JavaScript side
- add a mocked Jest test to verify telemetry emission for native error events

## Testing
- npm run typecheck
- npx jest src/services/__tests__/speech-error-telemetry.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e1c5d008248321ba757a2b46999dac