### PR TITLE
Align speech negotiation client with API route

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ subscription();
 
   End the stream with `Ctrl+C` once you observe `stt_final` firing.
 
+- **Negotiation pipeline** – Use `submitSpeechNegotiationSample()` from [`src/services/speechNegotiation.ts`](src/services/speechNegotiation.ts) to forward captured audio (Base64) to your backend `/api/speech-endpoint`. The helper automatically records end-to-end latency and error rate telemetry via the new `speech_pipeline_complete` event.
+
 - **Telemetry expectations** – Example payloads emitted via `trackSttEvent`:
 
   ```ts

--- a/docs/examples/telemetryExamples.ts
+++ b/docs/examples/telemetryExamples.ts
@@ -4,6 +4,7 @@ import type {
   OcrNativeFallbackTelemetryPayload,
   OcrOpenTelemetryPayload,
   OcrQuotaBlockedTelemetryPayload,
+  SpeechPipelineCompleteTelemetryPayload,
   SttErrorTelemetryPayload,
   SttFinalTelemetryPayload,
   SttOpenTelemetryPayload,
@@ -141,6 +142,24 @@ export const sttSendExamples: SttSendTelemetryPayload[] = [
     duration_ms: 3200,
     text_length: 18,
     transcript: '注文はコーヒーです',
+  },
+];
+
+export const speechPipelineCompleteExamples: SpeechPipelineCompleteTelemetryPayload[] = [
+  {
+    platform: 'ios',
+    provider: 'speech_pipeline',
+    duration_ms: 1250,
+    error_rate: 0,
+    transcript_length: 42,
+  },
+  {
+    platform: 'ios',
+    provider: 'speech_pipeline',
+    duration_ms: 980,
+    error_rate: 1,
+    error_code: 'network_failure',
+    error_message: 'ECONNRESET',
   },
 ];
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -448,6 +448,46 @@
 | `TextRecognizerResultCode.EMPTY` | `no_text_detected` | 無抽取文字。 |
 | `QuotaExceededException` | `quota_exhausted` | 達到月度配額限制。 |
 
+## 語音談判管線事件
+
+為了串接 iOS 語音辨識與後端談判模組，新增 `speech_pipeline_complete` 事件以衡量端到端反應時間與錯誤率。
+
+| 事件名稱 | 說明 |
+| --- | --- |
+| `speech_pipeline_complete` | 前端上傳語音後，後端完成轉文字、策略生成並回傳結果。 |
+
+### `speech_pipeline_complete`
+
+| Key | 型別 | 說明 |
+| --- | --- | --- |
+| `duration_ms` | `number` | 從送出語音請求到收到策略回應的總耗時。 |
+| `error_rate` | `0 \| 1` | 若請求失敗則為 `1`，成功為 `0`，便於後續統計錯誤率。 |
+| `transcript_length?` | `number` | 後端回傳文字長度。 |
+| `error_code?` | `NormalizedErrorCode` | 失敗時的標準化錯誤碼。 |
+| `error_message?` | `string` | 後端或網路層回傳的錯誤訊息。 |
+
+**範例 Payload**
+
+```ts
+[
+  {
+    platform: 'ios',
+    provider: 'speech_pipeline',
+    duration_ms: 1250,
+    error_rate: 0,
+    transcript_length: 42,
+  },
+  {
+    platform: 'ios',
+    provider: 'speech_pipeline',
+    duration_ms: 980,
+    error_rate: 1,
+    error_code: 'network_failure',
+    error_message: 'ECONNRESET',
+  },
+]
+```
+
 ## 實作建議
 
 - 優先完成 `stt_final` 後再觸發 `stt_send`，確保送出的文字與最後一次結果一致。

--- a/src/services/__tests__/speechNegotiation.test.ts
+++ b/src/services/__tests__/speechNegotiation.test.ts
@@ -1,0 +1,107 @@
+import {beforeEach, describe, expect, it, jest} from '@jest/globals';
+import type {AxiosError} from 'axios';
+import {submitSpeechNegotiationSample} from '../speechNegotiation';
+
+const mockPost: jest.Mock = jest.fn();
+const mockTrackSpeechPipelineEvent = jest.fn();
+const mockNormalizeTelemetryErrorCode = jest.fn((code: string) => code);
+
+jest.mock('react-native', () => ({
+  Platform: {OS: 'ios'},
+}));
+
+jest.mock('../api', () => ({
+  api: {
+    post: (...args: unknown[]) => mockPost(...args),
+  },
+}));
+
+jest.mock('../telemetry', () => ({
+  trackSpeechPipelineEvent: (...args: unknown[]) =>
+    mockTrackSpeechPipelineEvent(...args),
+  normalizeTelemetryErrorCode: (code: string) =>
+    mockNormalizeTelemetryErrorCode(code),
+}));
+
+describe('submitSpeechNegotiationSample', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('invokes backend endpoint and emits success telemetry', async () => {
+    const strategy = {
+      tone: 'neutral',
+      emotionScore: 0.6,
+      strategy: 'Stay calm and outline next steps.',
+      reply: 'Final reply',
+      matchedKeywords: [],
+    } as const;
+
+    mockPost.mockImplementationOnce(async () => ({
+      data: {transcript: 'hello world', strategy},
+    }));
+
+    const dateSpy = jest.spyOn(Date, 'now');
+    dateSpy.mockImplementationOnce(() => 1000);
+    dateSpy.mockImplementationOnce(() => 1600);
+
+    const result = await submitSpeechNegotiationSample({
+      audioBase64: 'base64data',
+    });
+
+    expect(result).toEqual({transcript: 'hello world', strategy});
+
+    expect(mockPost).toHaveBeenCalledWith('/api/speech-endpoint', {
+      audioBase64: 'base64data',
+    });
+
+    expect(mockTrackSpeechPipelineEvent).toHaveBeenCalledWith(
+      'speech_pipeline_complete',
+      expect.objectContaining({
+        platform: 'ios',
+        provider: 'speech_pipeline',
+        duration_ms: 600,
+        error_rate: 0,
+        transcript_length: 11,
+      }),
+    );
+
+    dateSpy.mockRestore();
+  });
+
+  it('tracks telemetry when the endpoint rejects', async () => {
+    const axiosError = new Error('network failure') as AxiosError & {
+      isAxiosError: true;
+    };
+    axiosError.isAxiosError = true;
+    axiosError.code = 'ECONNABORTED';
+
+    mockPost.mockImplementationOnce(async () => {
+      throw axiosError;
+    });
+
+    const dateSpy = jest.spyOn(Date, 'now');
+    dateSpy.mockImplementationOnce(() => 2000);
+    dateSpy.mockImplementationOnce(() => 2600);
+
+    await expect(
+      submitSpeechNegotiationSample({audioBase64: 'broken'}),
+    ).rejects.toThrow('network failure');
+
+    expect(mockNormalizeTelemetryErrorCode).toHaveBeenCalledWith(
+      'ECONNABORTED',
+    );
+
+    expect(mockTrackSpeechPipelineEvent).toHaveBeenCalledWith(
+      'speech_pipeline_complete',
+      expect.objectContaining({
+        duration_ms: 600,
+        error_rate: 1,
+        error_code: 'ECONNABORTED',
+        error_message: 'network failure',
+      }),
+    );
+
+    dateSpy.mockRestore();
+  });
+});

--- a/src/services/speechNegotiation.ts
+++ b/src/services/speechNegotiation.ts
@@ -1,0 +1,133 @@
+import {Platform} from 'react-native';
+import {isAxiosError} from 'axios';
+import type {NegotiationStrategyReply} from '../ai/negotiationStrategy';
+import {api} from './api';
+import {
+  normalizeTelemetryErrorCode,
+  trackSpeechPipelineEvent,
+} from './telemetry';
+import type {SpeechPipelineTelemetryPayloadFor} from '../types/telemetry';
+
+export interface SpeechNegotiationRequest {
+  audioBase64: string;
+  language?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SpeechNegotiationResponse {
+  transcript: string;
+  strategy: NegotiationStrategyReply;
+}
+
+const SPEECH_PIPELINE_PROVIDER = 'speech_pipeline';
+
+const getTelemetryPlatform = (): 'ios' | 'android' =>
+  Platform.OS === 'android' ? 'android' : 'ios';
+
+const buildTelemetryPayload = (
+  overrides: Partial<SpeechPipelineTelemetryPayloadFor<'speech_pipeline_complete'>>,
+): SpeechPipelineTelemetryPayloadFor<'speech_pipeline_complete'> => ({
+  platform: getTelemetryPlatform(),
+  provider: SPEECH_PIPELINE_PROVIDER,
+  duration_ms: overrides.duration_ms ?? 0,
+  error_rate: overrides.error_rate ?? 0,
+  transcript_length: overrides.transcript_length,
+  error_code: overrides.error_code,
+  error_message: overrides.error_message,
+});
+
+const resolveRawErrorCode = (error: unknown): string => {
+  if (isAxiosError(error)) {
+    const data = error.response?.data as {error_code?: string} | undefined;
+    if (data && typeof data.error_code === 'string' && data.error_code.length > 0) {
+      return data.error_code;
+    }
+
+    if (typeof error.code === 'string' && error.code.length > 0) {
+      return error.code;
+    }
+
+    if (typeof error.response?.status === 'number') {
+      return String(error.response.status);
+    }
+  }
+
+  if (
+    error &&
+    typeof (error as {code?: unknown}).code === 'string' &&
+    ((error as {code?: string}).code?.length ?? 0) > 0
+  ) {
+    return (error as {code: string}).code;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error ?? 'unknown_error');
+};
+
+const resolveErrorMessage = (error: unknown): string | undefined => {
+  if (isAxiosError(error)) {
+    const data = error.response?.data as {message?: string} | undefined;
+    if (data && typeof data.message === 'string' && data.message.length > 0) {
+      return data.message;
+    }
+
+    if (typeof error.message === 'string' && error.message.length > 0) {
+      return error.message;
+    }
+  }
+
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  if (typeof error === 'string' && error.trim().length > 0) {
+    return error;
+  }
+
+  return undefined;
+};
+
+export const submitSpeechNegotiationSample = async (
+  request: SpeechNegotiationRequest,
+): Promise<SpeechNegotiationResponse> => {
+  const start = Date.now();
+
+  try {
+    const response = await api.post<SpeechNegotiationResponse>(
+      '/api/speech-endpoint',
+      request,
+    );
+
+    const duration = Date.now() - start;
+    const transcriptLength = response.data?.transcript?.length ?? 0;
+
+    const telemetryPayload = buildTelemetryPayload({
+      duration_ms: duration,
+      error_rate: 0,
+      transcript_length: transcriptLength > 0 ? transcriptLength : undefined,
+    });
+
+    trackSpeechPipelineEvent('speech_pipeline_complete', telemetryPayload);
+
+    return response.data;
+  } catch (error) {
+    const duration = Date.now() - start;
+    const normalizedErrorCode = normalizeTelemetryErrorCode(
+      resolveRawErrorCode(error),
+    );
+
+    const telemetryPayload = buildTelemetryPayload({
+      duration_ms: duration,
+      error_rate: 1,
+      error_code: normalizedErrorCode,
+      error_message: resolveErrorMessage(error),
+    });
+
+    trackSpeechPipelineEvent('speech_pipeline_complete', telemetryPayload);
+
+    throw error;
+  }
+};

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -2,6 +2,8 @@ import type {
   NormalizedErrorCode,
   SttTelemetryEvent,
   SttTelemetryPayloadFor,
+  SpeechPipelineTelemetryEvent,
+  SpeechPipelineTelemetryPayloadFor,
 } from '../types/telemetry';
 
 declare const __DEV__: boolean;
@@ -127,6 +129,13 @@ export const normalizeTelemetryErrorCode = (
 export const trackSttEvent = <E extends SttTelemetryEvent>(
   event: E,
   payload: SttTelemetryPayloadFor<E>,
+): void => {
+  track(event, payload);
+};
+
+export const trackSpeechPipelineEvent = <E extends SpeechPipelineTelemetryEvent>(
+  event: E,
+  payload: SpeechPipelineTelemetryPayloadFor<E>,
 ): void => {
   track(event, payload);
 };

--- a/src/types/telemetry.ts
+++ b/src/types/telemetry.ts
@@ -26,6 +26,8 @@ export type SttTelemetryEvent =
   | 'stt_permission_denied'
   | 'stt_send';
 
+export type SpeechPipelineTelemetryEvent = 'speech_pipeline_complete';
+
 export interface SttOpenTelemetryPayload extends BaseTelemetryProps {
   locale?: string | null;
   native_flag?: boolean;
@@ -62,6 +64,14 @@ export interface SttSendTelemetryPayload extends BaseTelemetryProps {
   transcript?: string;
 }
 
+export interface SpeechPipelineCompleteTelemetryPayload extends BaseTelemetryProps {
+  duration_ms: number;
+  error_rate: 0 | 1;
+  transcript_length?: number;
+  error_code?: NormalizedErrorCode;
+  error_message?: string;
+}
+
 export type SttTelemetryPayloadMap = {
   stt_open: SttOpenTelemetryPayload;
   stt_partial: SttPartialTelemetryPayload;
@@ -75,6 +85,14 @@ export type SttTelemetryPayload = SttTelemetryPayloadMap[SttTelemetryEvent];
 
 export type SttTelemetryPayloadFor<Event extends SttTelemetryEvent> =
   SttTelemetryPayloadMap[Event];
+
+export type SpeechPipelineTelemetryPayloadMap = {
+  speech_pipeline_complete: SpeechPipelineCompleteTelemetryPayload;
+};
+
+export type SpeechPipelineTelemetryPayloadFor<
+  Event extends SpeechPipelineTelemetryEvent,
+> = SpeechPipelineTelemetryPayloadMap[Event];
 
 // OCR events
 export type OcrTelemetryEvent =


### PR DESCRIPTION
## Summary
- add a speech negotiation client service that posts audio to `/api/speech-endpoint` and records end-to-end telemetry
- document the new `speech_pipeline_complete` event and example payloads for the negotiation pipeline
- cover the pipeline with a unit test validating success and failure telemetry flows

## Testing
- npm run typecheck
- npx jest src/services/__tests__/speechNegotiation.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e1ced033a48321bab585494cc212d8